### PR TITLE
Add comprehensive AI agent research dossiers (Feb 2026)

### DIFF
--- a/research-llm-agents-feb-2026.md
+++ b/research-llm-agents-feb-2026.md
@@ -1,0 +1,510 @@
+# State of the Art: LLM Agents & AI Coding Tools — February 2026
+
+A comprehensive research dossier of the 100 most impressive, ingenious, and effective LLM agent projects, AI coding tools, and autonomous systems as of February 2026. Evaluated on **ingenuity, effectiveness, integrity, security, creativity, and impressiveness**. Sources limited to reputable platforms (GitHub, Substack, Medium, academic papers, major tech publications).
+
+---
+
+## CATEGORY 1: Autonomous Coding Agents (The Workhorses)
+
+### 1. Claude Code (Anthropic)
+- **What:** Terminal-native AI coding agent that reads entire codebases, writes multi-file solutions, runs tests, submits PRs
+- **Impressive:** Anthropic engineers write 70-90% of all code through Claude Code. Boris Cherny built the entire Cowork product via "vibe coding" with Claude Code in under two weeks. Google engineer Jaana Dogan confirmed Claude Code generated a distributed agent orchestration system in 60 minutes that her team iterated on throughout 2024. $1B ARR product.
+- [Bloomberg](https://www.bloomberg.com/news/articles/2026-02-26/ai-coding-agents-like-claude-code-are-fueling-a-productivity-panic-in-tech) | [Medium](https://tasmayshah12.medium.com/claude-code-how-a-side-project-became-the-ai-coding-tool-google-engineers-prefer-in-2025-73aaa6a54371) | [Built In](https://builtin.com/articles/anthropic-claude-code-tool)
+
+### 2. OpenHands (formerly OpenDevin)
+- **What:** Open-source platform for AI software developers — code editing, command execution, web browsing, API calls in a sandboxed environment
+- **Impressive:** 72% resolution rate on SWE-Bench Verified (with Claude Sonnet 4.5 + extended thinking). 65K+ GitHub stars. V1 SDK introduces event-sourced state model, typed tool system with MCP integration, workspace abstractions for local/remote execution.
+- [OpenHands](https://openhands.dev/) | [arXiv](https://arxiv.org/abs/2407.16741) | [Modal](https://modal.com/blog/open-ai-agents)
+
+### 3. Devin (Cognition AI)
+- **What:** First AI "software engineer" — autonomously plans, researches docs, adds debug statements, deploys code
+- **Impressive:** Shocked the developer world in 2024 with its end-to-end software task completion. Now used in production by enterprises. $500/month pricing reflects its autonomous capability.
+
+### 4. Cline (Open-Source VS Code Agent)
+- **What:** Open-source autonomous coding assistant for VS Code with dual Plan/Act modes
+- **Impressive:** 58.2K GitHub stars, 5M+ installs across VS Code, Cursor, JetBrains, Zed, Neovim. Feb 2026: shipped native subagents (v3.58) for parallel execution and Cline CLI 2.0 with headless CI/CD mode. Universal model support.
+- [Cline](https://cline.bot/)
+
+### 5. Cursor (AI-Augmented IDE)
+- **What:** Full IDE with AI tab completions, Agent mode for autonomous multi-file edits
+- **Impressive:** Tab completions using specialized lightweight model that predicts what you're about to type with codebase context — a "killer feature" no extension can replicate. 360K+ paying users. Scored 8.5/10 on code quality in benchmarks.
+
+### 6. Aider (Open-Source CLI)
+- **What:** Terminal-first AI pair programming tool with Git-aware diffs and universal model support
+- **Impressive:** 36K+ GitHub stars. Repo mapping builds internal map of entire codebase before making changes. Free tool — you only pay for LLM tokens.
+
+### 7. GitHub Copilot (Microsoft)
+- **What:** IDE-integrated AI pair programmer with autocomplete, Agent mode, and workspace features
+- **Impressive:** 15M+ users. Feb 26, 2026: Claude and Codex now available as coding agents inside Copilot Business/Pro. GitHub Agentic Workflows (technical preview) allow describing outcomes in Markdown that execute via coding agents in GitHub Actions.
+- [GitHub Blog](https://github.blog/changelog/2026-02-26-claude-and-codex-now-available-for-copilot-business-pro-users/)
+
+### 8. OpenAI Codex App
+- **What:** macOS coding agent app launched Feb 2, 2026; Codex CLI rewritten from TypeScript to Rust in Feb 2026
+- **Impressive:** Zero-dependency install. Catches logical errors, race conditions, edge cases. Multi-agent workflow support.
+- [Builder.io](https://www.builder.io/blog/codex-vs-claude-code)
+
+### 9. Google Jules
+- **What:** Autonomous AI coding agent for GitHub-based projects, powered by Gemini 3
+- **Impressive:** 140,000+ code improvements during beta. Jules Tools CLI & API for CI/CD integration. Gemini 3 Pro integration brings stronger intent alignment and multi-step reliability.
+
+### 10. SWE-agent (Princeton NLP)
+- **What:** Research agent specifically optimized for resolving GitHub issues
+- **Impressive:** Created by the authors of the SWE-Bench benchmark itself. Specifically tuned for issue resolution on 12 popular Python repos.
+
+### 11. Continue (Open-Source IDE Extension)
+- **What:** Open-source IDE extension for creating custom AI coding assistants
+- **Impressive:** 20K+ GitHub stars. Highly configurable — lets developers share custom agent configurations.
+
+---
+
+## CATEGORY 2: Enterprise AI Agent Platforms
+
+### 12. Claude Cowork (Anthropic)
+- **What:** Enterprise AI productivity platform for knowledge workers — sits between Claude.ai and Claude Code
+- **Impressive:** Launched Feb 24, 2026 with plugins for Google Drive, Gmail, DocuSign, FactSet. Private marketplace for department-specific agents (HR, design, engineering, finance). Sub-agent coordination — Claude breaks complex work into parallel workstreams. Caused S&P 500 Software Index's most volatile week in years.
+- [VentureBeat](https://venturebeat.com/orchestration/anthropic-says-claude-code-transformed-programming-now-claude-cowork-is)
+
+### 13. Spotify "Honk" System
+- **What:** Internal AI deployment tool interfacing with Claude Code for engineering teams
+- **Impressive:** Best developers haven't written a line of code since December 2025. Engineers deploy fixes via Slack from their phones. 90% reduction in engineering time. 650+ AI-generated code changes shipped/month. ~50% of all Spotify updates flow through the system.
+- [TechCrunch](https://techcrunch.com/2026/02/12/spotify-says-its-best-developers-havent-written-a-line-of-code-since-december-thanks-to-ai/)
+
+### 14. Shopify Winter '26 "Renaissance Edition"
+- **What:** AI-native commerce OS with agentic storefronts, Sidekick as "Full-Stack Operator"
+- **Impressive:** AI agents handle full commerce workflows. In-chat checkout via OpenAI partnership in ChatGPT. Sidekick gains write access to critical infrastructure.
+
+### 15. Salesforce + Claude
+- **What:** Claude models powering AI in Slack
+- **Impressive:** 96% satisfaction rate, saving customers ~97 minutes/week.
+
+---
+
+## CATEGORY 3: Agent Frameworks & Orchestration
+
+### 16. LangChain / LangGraph
+- **What:** The go-to toolkit for LLM applications — modular prompt chaining, tool integration, memory management. LangGraph adds stateful multi-agent DAG workflows.
+- **Impressive:** 99,600 GitHub stars, 27M monthly downloads. Industry standard.
+
+### 17. CrewAI
+- **What:** Multi-agent orchestration framework for role-playing AI agents
+- **Impressive:** 44K+ GitHub stars, 5.2M monthly downloads. After analyzing 1.7 billion agentic workflows, found the winning pattern: "deterministic backbone with intelligence deployed where it matters."
+
+### 18. OpenAI Agents SDK
+- **What:** Lightweight Python framework for multi-agent workflows with tracing and guardrails
+- **Impressive:** 19K+ GitHub stars, 10.3M monthly downloads. Provider-agnostic (100+ LLMs). Multi-agent triage system in ~30 lines of Python.
+
+### 19. AutoGen / AG2 (Microsoft)
+- **What:** Multi-agent conversation framework — define specialized agents (planner, researcher, coder, reviewer) that communicate to solve complex tasks
+- **Impressive:** Oct 2025: merged with Semantic Kernel into unified Microsoft Agent Framework. One of the most creative paradigms for research and experimentation.
+
+### 20. Google ADK (Agent Development Kit)
+- **What:** Framework for complex workflow orchestration with Sequential, Loop, and Parallel agents
+- **Impressive:** First-class OpenAPI spec support, secure auth, deep GCP integration. Enterprise-grade.
+
+### 21. Pydantic AI
+- **What:** Model-agnostic agent framework supporting 25+ providers
+- **Impressive:** MCP + A2A support, durable execution for long workflows, built-in eval system for systematic testing, OpenTelemetry observability.
+
+### 22. Smolagents (Hugging Face)
+- **What:** Lightweight framework where agents write and execute Python code directly, bypassing JSON
+- **Impressive:** Eliminates the bottleneck of translating intentions into structured data. Minimal setup. Ideal for rapid prototyping.
+
+### 23. Dify
+- **What:** Open-source LLM app development platform with visual interface, RAG, agent capabilities
+- **Impressive:** Full-stack observability, rapid prototyping for AI apps. Strong community.
+- [NocoBase](https://www.nocobase.com/en/blog/github-open-source-ai-agent-projects)
+
+### 24. n8n
+- **What:** Open-source workflow automation with native AI capabilities
+- **Impressive:** 400+ integrations. Visual no-code interface combined with code flexibility. Now serves as MCP server for AI agent workflows.
+
+### 25. Semantic Kernel (Microsoft)
+- **What:** Enterprise-grade SDK underpinning Microsoft 365 Copilot
+- **Impressive:** 22.9K GitHub stars, 2.6M downloads. Powers flagship Microsoft products.
+
+---
+
+## CATEGORY 4: Protocols & Interoperability Standards
+
+### 26. Model Context Protocol (MCP)
+- **What:** Open standard by Anthropic (Nov 2024) for AI-to-tool integration — "USB-C for AI"
+- **Impressive:** Adopted by OpenAI, Google DeepMind. SDKs in Python, TypeScript, C#, Java, Go. Hosted by Linux Foundation. Official servers for filesystem, git, memory, fetch, sequential thinking.
+- [GitHub](https://github.com/modelcontextprotocol/servers) | [Wikipedia](https://en.wikipedia.org/wiki/Model_Context_Protocol)
+
+### 27. Agent2Agent (A2A) Protocol
+- **What:** Open standard by Google (Apr 2025) for agent-to-agent communication
+- **Impressive:** Now at Linux Foundation. Supports API Key, OAuth 2.0, OpenID Connect, mTLS auth. Microsoft, IBM, Google actively engaged. CareerAgent production system demonstrates 4-agent coordination over A2A.
+- [IBM](https://www.ibm.com/think/topics/agent2agent-protocol)
+
+### 28. Agent Skills Ecosystem
+- **What:** Modular capabilities for AI agent architecture across Claude Code, Codex, Gemini CLI, Cursor, VS Code, Copilot
+- **Impressive:** Official skills catalogs from Anthropic, OpenAI, Microsoft, Vercel, Supabase. Standardizing agent extensibility.
+
+---
+
+## CATEGORY 5: Viral Open-Source Agents
+
+### 29. OpenClaw (formerly Clawdbot/Moltbot)
+- **What:** Self-hosted personal AI agent running on your devices, connecting WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Teams
+- **Impressive:** 236K+ GitHub stars, 45K+ forks — exploded from hobby project (Nov 2025) to one of the most-starred repos on GitHub. Creator Peter Steinberger hired by OpenAI. MIT licensed.
+- **Security Note:** Cisco found third-party skills performing data exfiltration/prompt injection without user awareness.
+- [GitHub](https://github.com/openclaw/openclaw) | [Wikipedia](https://en.wikipedia.org/wiki/OpenClaw)
+
+### 30. AutoGPT
+- **What:** One of the first autonomous AI agents — chains LLM calls for self-directed task completion
+- **Impressive:** 177K GitHub stars. Pioneered the concept of autonomous AI agents for the public.
+
+### 31. Open Interpreter
+- **What:** Enables LLMs to execute code locally via natural language
+- **Impressive:** 60K+ GitHub stars. Facilitates natural-language interaction with your computer's capabilities.
+
+### 32. Nanobot
+- **What:** Ultra-lightweight personal AI assistant inspired by OpenClaw — core functionality in ~4,000 lines of code
+- **Impressive:** 99% smaller than OpenClaw's 430K+ lines while delivering core agent functionality.
+- [GitHub](https://github.com/HKUDS/nanobot)
+
+---
+
+## CATEGORY 6: Deep Research Agents
+
+### 33. Perplexity Deep Research
+- **What:** Autonomous research agent that spends 2-4 minutes doing work that would take a human expert hours
+- **Impressive:** State-of-the-art on DeepSearchQA and ResearchRubrics benchmarks. 89.4% pass rate in Law, 82.4% in Academic on DRACO benchmark.
+- [Perplexity](https://www.perplexity.ai/hub/blog/introducing-perplexity-deep-research)
+
+### 34. Perplexity "Computer" (Feb 26, 2026)
+- **What:** Multi-model agent platform coordinating 19 models — Claude Opus 4.6 for orchestration, Gemini for research, GPT-5.2 for long-context recall, specialized models for image/video
+- **Impressive:** The most ambitious multi-model orchestration system launched to date. Single prompt triggers complex workflows across specialized AI systems.
+- [VentureBeat](https://venturebeat.com/technology/perplexity-launches-computer-ai-agent-that-coordinates-19-models-priced-at)
+
+### 35. OpenAI Deep Research (ChatGPT)
+- **What:** o3-based research agent with multi-step reasoning, web browsing, data analysis
+- **Impressive:** Behaves as an analytical engine rather than search tool. Now accessible to ChatGPT Plus users (10 queries/month).
+- [Helicone](https://www.helicone.ai/blog/openai-deep-research)
+
+### 36. Google Gemini Deep Research
+- **What:** Autonomous research agent inside Gemini Advanced
+- **Impressive:** Browses 100+ web pages per query — significantly more than competitors. Exports directly to Google Docs.
+
+---
+
+## CATEGORY 7: Scientific Discovery Agents
+
+### 37. AI Scientist-v2
+- **What:** Autonomously formulates hypotheses, runs virtual experiments, writes peer-reviewed papers
+- **Impressive:** End-to-end automation of the scientific method. Published workshop papers entirely via AI agents.
+
+### 38. Red Queen Bio + GPT-5 Gene Editing
+- **What:** OpenAI lab experiment optimizing gene-editing protocols
+- **Impressive:** Achieved a 79x efficiency gain in actual lab experiments. Heralds "AI-augmented experimentation."
+
+### 39. GPT-5 Pro Black Hole Symmetry Discovery
+- **What:** Physicist Alex Lupsasca tested GPT-5 Pro on black hole event horizon equations
+- **Impressive:** AI independently discovered the same new symmetries the physicist found — and found an easier path. Lupsasca subsequently joined OpenAI's "OpenAI for Science" team.
+
+### 40. Lawrence Berkeley National Lab Data Science Agent
+- **What:** Google's Data Science Agent applied to tropical wetland methane emissions research
+- **Impressive:** Reduced analysis time from one week to five minutes.
+
+### 41. UCLA Math Proof Discovery (GPT-5 Pro)
+- **What:** Mathematician Ernest Ryu discovered new proof with 12 hours of AI collaboration
+- **Impressive:** Proved a popular optimization method always converges on a single solution — a genuine mathematical discovery.
+
+---
+
+## CATEGORY 8: Cybersecurity & CTF Agents
+
+### 42. Cybersecurity AI (CAI)
+- **What:** Framework that has achieved Rank #1 at multiple prestigious hacking competitions
+- **Impressive:** Captured 41/45 flags at Neurogrid ($50K prize). Sprinted 37% faster than elite human teams at Dragos OT CTF. Authors argue "Jeopardy-style CTFs have become a solved game for well-engineered AI agents."
+- [arXiv](https://arxiv.org/pdf/2512.02654) | [GitHub](https://github.com/aliasrobotics/cai)
+
+### 43. Wiz AI Hacking Research
+- **What:** Tested Claude Sonnet 4.5, GPT-5, Gemini 2.5 Pro in realistic hacking scenarios
+- **Impressive:** Agents highly proficient at directed vulnerability exploitation at $1-$10 per success. Wider-scope runs 2-2.5x more expensive but still viable.
+
+---
+
+## CATEGORY 9: Browser Automation & Computer Use Agents
+
+### 44. Opera Neon
+- **What:** AI-native browser with four specialized agents (web automation, code generation, deep research, chat)
+- **Impressive:** Built for autonomous action, not just assistance. Represents the "agentic browser" paradigm shift.
+
+### 45. browser-use Library
+- **What:** Open-source Python/TypeScript SDK for AI-powered browser automation
+- **Impressive:** The go-to open-source solution. LLM-powered decision making for website interaction.
+
+### 46. Vercel agent-browser
+- **What:** CLI tool for multimodal AI models to reason about visual layout
+- **Impressive:** Handles unlabeled icons, canvas elements, visual state that text accessibility trees can't capture.
+- [GitHub](https://github.com/vercel-labs/agent-browser)
+
+### 47. ai.com Consumer Agent (Super Bowl LX)
+- **What:** Personal AI agent that operates on users' behalf — launched Feb 8, 2026 during Super Bowl LX
+- **Impressive:** Consumer-facing autonomous AI agent with Super Bowl premiere. Anyone can generate a private AI agent with a few clicks.
+
+---
+
+## CATEGORY 10: Vibe Coding & App Builder Agents
+
+### 48. Bolt.new (StackBlitz)
+- **What:** Browser-based full-stack app generator using Claude
+- **Impressive:** Fastest to working prototype (~28 min in benchmarks). Went viral for spinning up full-stack apps with instant previews.
+- [Medium](https://medium.com/@aftab001x/the-2026-ai-coding-platform-wars-replit-vs-windsurf-vs-bolt-new-f908b9f76325)
+
+### 49. Lovable
+- **What:** AI app builder generating React + TypeScript + Supabase integration
+- **Impressive:** Beautiful component architecture. Fastest path to polished MVP for founders. Recommended starting point by multiple reviews.
+
+### 50. Replit
+- **What:** Browser IDE + AI agent platform for full-stack development and deployment
+- **Impressive:** Complete cloud development environment with real-time collaboration, AI agents, and integrated hosting. Bridges technical and non-technical users.
+
+### 51. Windsurf (Cascade)
+- **What:** AI-powered code editor with Supercomplete autocomplete
+- **Impressive:** Best-in-class multi-line autocomplete (beats Copilot). Scored 8.5/10 on code quality — most production-ready output of AI builders.
+
+### 52. SiteGround Coderick AI (Feb 2026)
+- **What:** Vibe coding tool transforming natural language into production-ready websites with built-in hosting and security
+- **Impressive:** End-to-end from prompt to deployed, hosted website.
+
+### 53. Aircraft MRO System (Claude Code)
+- **What:** AI-native enterprise app — 55 entities, 78 API endpoints, 114 UI components, 100K+ lines
+- **Impressive:** Claude Code generated autonomously in 20 hours. Demonstrates scale of vibe-coded enterprise systems (AI generated ~50-60% of final production code).
+- [Medium](https://anil789.medium.com/we-built-a-100k-line-enterprise-app-using-ai-heres-why-vibe-coding-couldn-t-4f1220d08203)
+
+---
+
+## CATEGORY 11: Industry-Specific Production Agents
+
+### 54. Sedgwick Sidekick Agent (Insurance)
+- **What:** Microsoft-powered claims processing agent
+- **Impressive:** 30%+ improvement in claims processing efficiency through real-time guidance.
+
+### 55. Suzano AI Agent (Manufacturing)
+- **What:** Materials data query agent
+- **Impressive:** 95% reduction in query time for materials data.
+
+### 56. Danfoss Order Processing (Manufacturing)
+- **What:** Transactional order processing automation
+- **Impressive:** 80% automation of order processing decisions.
+
+### 57. Elanco Document Management (Pharma)
+- **What:** Automated document management for pharmaceutical operations
+- **Impressive:** Up to $1.3 million in avoided productivity impact per site.
+
+### 58. Providence Health Care (Multi-Agent System)
+- **What:** Memora Health coordination/multi-agent system
+- **Impressive:** Monitors patient recovery and manages follow-up appointments autonomously.
+
+---
+
+## CATEGORY 12: MCP Server Ecosystem (Best Implementations)
+
+### 59. GitHub MCP Server
+- **What:** Lets agents execute, test, commit code changes inside repos
+- **Impressive:** Major leap for DevOps automation. Agents can autonomously manage repositories.
+
+### 60. Supabase MCP Server
+- **What:** Transforms dev workflows into natural language commands
+- **Impressive:** Indispensable for AI-first app development. Database operations via conversation.
+
+### 61. Zapier MCP Server
+- **What:** Connects agents to 7,000+ app actions through unified server
+- **Impressive:** Democratizes tool access for AI clients. Massive integration surface.
+
+### 62. Chroma MCP Server (Vector Search)
+- **What:** Semantic document management and retrieval for AI workflows
+- **Impressive:** Sets the standard for LLM contextual memory via vector search.
+
+### 63. n8n MCP Server
+- **What:** Bridges low-code automation with AI agent workflows
+- **Impressive:** Agents trigger workflows, integrate systems, orchestrate logic flows.
+
+### 64. Sequential Thinking MCP Server (Anthropic)
+- **What:** Dynamic and reflective problem-solving through thought sequences
+- **Impressive:** Official reference implementation showcasing deliberative reasoning in MCP.
+- [GitHub](https://github.com/modelcontextprotocol/servers)
+
+---
+
+## CATEGORY 13: Research & Academic Breakthroughs
+
+### 65. MIT EnCompass Framework (Feb 2026)
+- **What:** Executes AI agent programs with backtracking, parallel clones, and path search
+- **Impressive:** Automatically backtracks on LLM mistakes. Searches over different possible agent paths. Makes agent programming more reliable.
+
+### 66. Chain of Agents
+- **What:** Training-free, task-agnostic framework using LLM collaboration for long-context tasks
+- **Impressive:** Outperforms both RAG and long-context LLMs without any fine-tuning.
+
+### 67. Cache-to-Cache (C2C)
+- **What:** Direct semantic communication between LLMs using internal KV-cache
+- **Impressive:** Bypasses text generation for richer, lower-latency inter-model collaboration. Novel approach to agent communication.
+
+### 68. MultiAgentBench
+- **What:** Benchmark for evaluating multi-agent collaboration and competition
+- **Impressive:** Open-sourced code/data. First systematic evaluation of multi-agent LLM systems.
+
+### 69. SWE-EVO Benchmark
+- **What:** Next-gen benchmark addressing SWE-Bench limitations
+- **Impressive:** Captures continuous software evolution rather than discrete issue resolution.
+
+### 70. ClawWork GDP Benchmark
+- **What:** 220 GDP validation tasks spanning 44 economic sectors
+- **Impressive:** Tests real-world work capability of AI agents across diverse economic domains.
+- [GitHub](https://github.com/HKUDS/ClawWork)
+
+### 71. "Agents of Chaos" Study (arXiv, Feb 2026)
+- **What:** Documents real agent failures — data leaks, destructive actions, identity spoofing
+- **Impressive:** Critical safety research. Essential reading for anyone deploying agents in production.
+
+---
+
+## CATEGORY 14: Multi-Agent Production Architectures
+
+### 72. CareerAgent (A2A Production System)
+- **What:** Four specialist agents coordinating over A2A protocol — Orchestrator, Analyzer, Resume Builder, Interviewer
+- **Impressive:** Each agent runs independently on its own port, publishes Agent Cards, accepts tasks via JSON-RPC 2.0. Full A2A specification implementation.
+
+### 73. Hierarchical Multi-Agent Discovery Systems
+- **What:** Tree-structured architecture with meta-orchestrators, domain specialists, task-specific scientists
+- **Impressive:** Dynamic reorganization — frequently collaborating agents merge into unified teams. Proposed for autonomous scientific research.
+
+### 74. IBM Retail Multi-Agent (A2A + MCP)
+- **What:** Inventory agent (MCP) communicates with external supplier agents (A2A) for automated reordering
+- **Impressive:** Demonstrates complementary use of both protocols in production retail scenario.
+- [IBM](https://www.ibm.com/think/topics/agent2agent-protocol)
+
+---
+
+## CATEGORY 15: Notable Curated Resources & Awesome Lists
+
+### 75. [500-AI-Agents-Projects](https://github.com/ashishpatel26/500-AI-Agents-Projects)
+- 500 AI agent use cases across healthcare, finance, education, retail with open-source links
+
+### 76. [awesome-ai-agent-papers (VoltAgent)](https://github.com/VoltAgent/awesome-ai-agent-papers)
+- 2026-only papers from arXiv, updated weekly
+
+### 77. [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps)
+- Practical LLM apps combining agents, RAG, MCP across OpenAI, Anthropic, Gemini, open-source
+
+### 78. [awesome-cli-agents](https://github.com/phamquiluan/awesome-cli-agents)
+- CLI tools for AI in Vim, Neovim, and Terminal (updated Feb 11, 2026)
+
+### 79. [The Agentic List 2026](https://agentconference.substack.com/p/we-just-released-the-agentic-list)
+- 120 most promising companies building enterprise agentic AI, $31B+ total funding across 14 categories
+
+### 80. [Awesome-AI-Market-Maps](https://github.com/joylarkin/Awesome-AI-Market-Maps)
+- 400+ AI market maps from 2025-2026
+
+---
+
+## CATEGORY 16: Emerging Frontier Agents
+
+### 81. Meta Manus Agents (Telegram)
+- **What:** AI tools (video generation, image creation, Gmail/Notion integration) in private Telegram chats
+- **Impressive:** Expanding to WhatsApp, Slack. Consumer-facing multi-capability agent.
+
+### 82. Devika
+- **What:** Agentic AI Software Engineer that breaks down high-level instructions, researches, writes code
+- **Impressive:** Open-source alternative to Devin. Featured in multiple awesome-agents lists.
+
+### 83. Pathway (Real-Time Data Agents)
+- **What:** Framework for agents reacting to real-time data streams
+- **Impressive:** 50K+ GitHub stars. Critical for enterprises deploying agents that must react to live data.
+
+### 84. VoltAgent
+- **What:** Open-source TypeScript framework for AI agents with built-in LLM observability
+- **Impressive:** Developer-friendly. Built-in observability from day one.
+
+### 85. PraisonAI
+- **What:** Production-ready multi-agent framework with self-reflection
+- **Impressive:** Fastest agent instantiation (3.77us). 100+ LLM support. MCP integration. Python & JavaScript SDKs.
+
+### 86. OpenCode
+- **What:** AI coding agent built for the terminal (open-source)
+- **Impressive:** Featured in Feb 2026 comparisons alongside Claude Code and Codex.
+
+### 87. Strands Agents SDK (AWS)
+- **What:** Model-driven approach to building AI agents in a few lines of code
+- **Impressive:** AWS-backed. Listed among top agent frameworks.
+
+### 88. Blinky (VS Code Debugging Agent)
+- **What:** Open-source debugging agent using Language Server Protocol
+- **Impressive:** Leverages LSP for deep code understanding in debugging. Novel approach.
+
+---
+
+## CATEGORY 17: Key LLM Models Powering Agents (Feb 2026 Rankings)
+
+### 89. Claude Opus 4.6 (Anthropic)
+- 1M token context window. Leads SWE-Bench Verified at 72.5%. Strongest coder among frontier models. Powers Perplexity Computer orchestration.
+
+### 90. GPT-5.2 Pro (OpenAI)
+- Highest reasoning scores from a production model (93.2% GPQA Diamond). Perfect AIME 2025 score.
+
+### 91. DeepSeek V3.2-Speciale
+- Near-frontier performance at ~1/30th the cost of GPT-5.2 Pro. Reshaping the industry's cost structure.
+
+### 92. Gemini 3 Pro (Google)
+- Surpasses 2.5 Pro at coding. Stronger agentic workflows in Jules. Improved intent alignment.
+
+### 93. Qwen 3.5 (Alibaba)
+- Top-10 coding model. Growing in the open-source community.
+
+---
+
+## CATEGORY 18: Security & Governance Developments
+
+### 94. MCP Security Guide (Feb 2026)
+- **What:** MCP v2.1 security specification covering OAuth, mTLS, Zero Trust
+- **Impressive:** Classified MCP servers as OAuth Resource Servers. RFC 8707 Resource Indicators to prevent token misuse.
+- [DasRoot](https://dasroot.net/posts/2026/02/securing-model-context-protocol-oauth-mtls-zero-trust/)
+
+### 95. Cline npm Publish Incident (Feb 2026)
+- **What:** Security incident cited as strong example of agentic threat landscape
+- **Impressive:** Real-world demonstration of supply chain risks in AI agent ecosystems.
+
+### 96. BodySnatcher & ZombieAgent Vulnerabilities
+- **What:** Agent hijacking vulnerabilities in ServiceNow and persistent exploit patterns
+- **Impressive:** Demonstrates the "superuser problem" — autonomous agents with broad permissions creating security blind spots.
+
+### 97. Memory Poisoning Attacks
+- **What:** Adversaries implant false info into agent long-term storage that persists across sessions
+- **Impressive:** Unlike prompt injection that ends with the chat, poisoned memory persists indefinitely. Novel attack vector.
+
+---
+
+## CATEGORY 19: Market Intelligence
+
+### 98. The Agentic AI Market
+- $7.84B in 2025 → projected $52.62B by 2030 (CAGR 46.3%)
+- 40% of enterprise apps will feature AI agents by end of 2026 (Gartner)
+- 92% of US developers use AI coding tools daily
+- 41% of all code written globally is now AI-generated
+- 30% of code at Google and Microsoft written by AI
+
+### 99. Anthropic's Growth Trajectory
+- $1B ARR (Dec 2024) → $4B (mid-2025) → $9B (end 2025) → $14B (Feb 2026)
+- 14x growth in 14 months — fastest B2B software scaling in history
+- $30B funding round at $380B valuation (Feb 2026)
+- Enterprise contracts = 80% of revenue
+
+### 100. The Hybrid Workflow Paradigm
+- Many teams now: Claude Code generates features → Codex reviews before merge
+- Tool specialization > tool consolidation
+- "The agents that work are the boring ones: narrow, specialized, deeply integrated"
+- "AI becomes invisible scaffolding inside the tools people already use"
+
+---
+
+## Key Takeaways
+
+1. **The coding agent war is real** — Claude Code, Codex, Copilot, Cursor, Cline, and OpenHands are all formidable, and the best teams use multiple tools strategically
+2. **Protocols matter** — MCP (tool access) and A2A (agent-to-agent) are becoming the TCP/IP of the agent era
+3. **The boring agents win** — narrow, specialized, deeply integrated agents outperform ambitious generalists in production
+4. **Security is the blind spot** — memory poisoning, supply chain attacks, agent hijacking are all real threats that the ecosystem hasn't fully addressed
+5. **Science is being transformed** — from 79x gene editing gains to mathematical proofs to black hole symmetry discoveries, agents are accelerating research
+6. **The market is exploding** — $7.8B → $52B projected by 2030, with 40% of enterprise apps embedding agents by end of 2026

--- a/research-top-agent-toolkits-feb-2026.md
+++ b/research-top-agent-toolkits-feb-2026.md
@@ -1,0 +1,440 @@
+# Top Uses of AI Agent Tools: Full Suites, Workflows, Configurations & Production Setups — February 2026
+
+A comprehensive research dossier of the most impressive configurations, prompt libraries, workflow templates, CLAUDE.md files, .cursorrules, agent orchestration setups, hooks, skills, slash commands, and production pipelines across the AI coding ecosystem. Evaluated on **ingenuity, effectiveness, integrity, security, creativity, and impressiveness**.
+
+---
+
+## CATEGORY 1: Claude Code Full Configuration Suites
+
+### 1. everything-claude-code (affaan-m)
+- **What:** Complete Claude Code configuration collection — 13 agents, 48 skills, 32 commands, hooks, rules, MCPs
+- **Why chosen:** Battle-tested at the Claude Code Hackathon (Cerebral Valley x Anthropic, Feb 2026). 1,282 tests, 98% coverage, 102 static analysis rules. Includes **AgentShield** — a security scanner that audits CLAUDE.md, settings.json, MCP configs, hooks, agent definitions, and skills for vulnerabilities, misconfigurations, and injection risks. The `--opus` flag runs three Claude Opus 4.6 agents in a red-team/blue-team/auditor pipeline.
+- **What sets it apart:** The only config suite with built-in security scanning and adversarial red-team testing of your own agent setup.
+- [github.com/affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code)
+
+### 2. awesome-claude-code-toolkit (rohitg00)
+- **What:** 135 agents, 35 curated skills (+15,000 via SkillKit), 42 commands, 120 plugins, 19 hooks, 15 rules, 7 templates, 6 MCP configs
+- **Why chosen:** Sheer scale — the most comprehensive single toolkit for Claude Code. 19 hook scripts cover all 8 Claude Code lifecycle events. Includes an onboarding command that bootstraps new developers into any codebase.
+- **What sets it apart:** Breadth. No other single repo packages this many production-ready components together.
+- [github.com/rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit)
+
+### 3. Trail of Bits claude-code-config
+- **What:** Opinionated defaults, documentation, and workflows from an elite cybersecurity firm
+- **Why chosen:** Written by security professionals who audit code for a living. Development philosophy: no speculative features, no premature abstraction, replace don't deprecate. Code quality hard limits on function length, complexity, line width. Critical insight: "An instruction in CLAUDE.md saying 'never use rm -rf' can be forgotten. A PreToolUse hook that blocks rm -rf fires every single time."
+- **What sets it apart:** Security-first mindset from the world's top code auditing firm. Hooks over instructions philosophy.
+- [github.com/trailofbits/claude-code-config](https://github.com/trailofbits/claude-code-config)
+
+### 4. Claude-Command-Suite (qdhenry)
+- **What:** 148+ slash commands, 54 AI agents, Claude Code Skills, and automated workflows
+- **Why chosen:** Covers code review, testing, deployment, business scenario modeling, and GitHub-Linear synchronization through structured, repeatable workflows. Professional-grade structured workflows for security auditing and architectural analysis.
+- **What sets it apart:** 148+ slash commands — the largest single command library. Business scenario modeling alongside technical workflows.
+- [github.com/qdhenry/Claude-Command-Suite](https://github.com/qdhenry/Claude-Command-Suite)
+
+### 5. Claude Code Showcase (ChrisWiles)
+- **What:** Comprehensive project configuration example with hooks, skills, agents, commands, and GitHub Actions workflows
+- **Why chosen:** Includes a code review agent following detailed checklists (TypeScript strict mode, error handling, loading states, mutation patterns). GitHub Action for automatic PR reviews. Scheduled agents: monthly docs sync, weekly code quality reviews, biweekly dependency audits. JIRA/Linear integration via MCP servers — Claude reads tickets, implements features, updates status.
+- **What sets it apart:** The scheduled agent pattern — automated quality maintenance running on cron-like cycles.
+- [github.com/ChrisWiles/claude-code-showcase](https://github.com/ChrisWiles/claude-code-showcase)
+
+### 6. Claude Code Best Practice (shanraisshan)
+- **What:** Concise best practice guide for CLAUDE.md, skills, agents, hooks, memory, rules, MCP servers, plugins
+- **Why chosen:** Key insight: CLAUDE.md should not exceed 150 lines. Recommends feature-specific subagents with skills (progressive disclosure) instead of general QA or backend engineer agents.
+- **What sets it apart:** Emphasis on constraint — knowing what NOT to put in CLAUDE.md is as important as what to include.
+- [github.com/shanraisshan/claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice)
+
+### 7. Claude Code Team Collaboration Guide (jsnkle)
+- **What:** Ready-to-use templates with full `.claude/` directory structures for team collaboration
+- **Why chosen:** Complete templates including CLAUDE.md, settings.json, rules for code-style/git-workflow/testing, commands, agents, skills. Framework-specific templates (React). Designed for small team deployment — the gap most other resources miss.
+- **What sets it apart:** Team-first design. Most configs are solo-developer focused; this addresses multi-developer coordination.
+- [github.com/jsnkle/Claude-Code-Team-Collaboration-Guide](https://github.com/jsnkle/Claude-Code-Team-Collaboration-Guide)
+
+### 8. Claude Code Skill Factory (alirezarezvani)
+- **What:** Toolkit for building and deploying production-ready Claude Skills, Agents, Slash Commands, and Prompts at scale
+- **Why chosen:** Interactive builders (`/build skill`, `/build agent`, `/build prompt`, `/build hook`). Hook factory supporting 7 event types. Meta-tooling — it builds the builders.
+- **What sets it apart:** A factory, not a library. Instead of pre-built skills, it gives you tools to manufacture your own at scale.
+- [github.com/alirezarezvani/claude-code-skill-factory](https://github.com/alirezarezvani/claude-code-skill-factory)
+
+### 9. Claude-Code-Everything-You-Need-to-Know (wesammustafa)
+- **What:** Ultimate all-in-one guide: setup, prompt engineering, commands, hooks, workflows, automation, MCP servers, BMAD method
+- **Why chosen:** Documents 2026-specific features: interactive `/hooks` command, new `TaskCompleted` hook event, hooks returning `updatedInput` to modify tool parameters. Living documentation tracking bleeding-edge features.
+- **What sets it apart:** Living documentation that tracks features as they ship — always current.
+- [github.com/wesammustafa/Claude-Code-Everything-You-Need-to-Know](https://github.com/wesammustafa/Claude-Code-Everything-You-Need-to-Know)
+
+### 10. Claude Code Hooks Mastery (disler)
+- **What:** Deterministic and non-deterministic control over Claude Code via hooks, sub-agents, and the meta-agent
+- **Why chosen:** Introduces the "meta-agent" — a specialized sub-agent that generates new sub-agents from descriptions. The "agent that builds agents." UV single-file scripts keep hook logic cleanly separated.
+- **What sets it apart:** The meta-agent pattern — self-generating agent infrastructure.
+- [github.com/disler/claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery)
+
+---
+
+## CATEGORY 2: Multi-Agent Orchestration Systems
+
+### 11. Ruflo (formerly Claude Flow) (ruvnet)
+- **What:** Enterprise AI agent orchestration — 60+ specialized agents, distributed swarm intelligence, 215 MCP tools
+- **Why chosen:** 5,800+ commits, 55 alpha iterations, now production-ready v3.5.0. Agents organize into swarms led by "queens" that coordinate work, prevent drift, reach consensus even when agents fail. Self-learning neural capabilities — learns from every execution, prevents catastrophic forgetting.
+- **What sets it apart:** Swarm intelligence with queen-worker topology and self-learning — the most ambitious open-source orchestration system.
+- [github.com/ruvnet/ruflo](https://github.com/ruvnet/ruflo)
+
+### 12. Continuous-Claude-v2 (2.2K stars)
+- **What:** Context management for Claude Code with hooks maintaining state via ledgers and handoffs
+- **Why chosen:** Solves the critical problem of context loss across sessions. MCP execution without context pollution. Agent orchestration with isolated context windows. Predecessor pioneered running Claude Code in a continuous loop — autonomously creating PRs, waiting for checks, merging.
+- **What sets it apart:** Stateful orchestration surviving context window boundaries — the "long-running agent" problem solved.
+- [github.com/jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code)
+
+### 13. crystal (2.7K stars)
+- **What:** Run multiple Claude Code sessions in parallel git worktrees
+- **Why chosen:** Parallel execution across isolated worktrees — multiple agents work on different features simultaneously without merge conflicts. Each agent gets a clean copy of the repo.
+- **What sets it apart:** Git worktree isolation for true parallel multi-agent development — simple concept, powerful execution.
+- [github.com/jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code)
+
+### 14. Claude Code Swarm Orchestration Skill (kieranklaassen)
+- **What:** Complete guide to multi-agent coordination with TeammateTool, Task system, and all patterns
+- **Why chosen:** Tested/verified 2026-01-25. Reveals Claude Flow V3's swarm system and Claude Code's TeammateTool share striking architectural similarities. Demonstrates 5-terminal-pane setup with specialized agents for each layer.
+- **What sets it apart:** The Rosetta Stone between orchestration approaches — shows they're all converging on the same patterns.
+- [gist.github.com/kieranklaassen](https://gist.github.com/kieranklaassen/4f2aba89594a4aea4ad64d753984b2ea)
+
+### 15. myclaude (stellarlinkco)
+- **What:** Multi-agent orchestration supporting Claude Code, Codex, Gemini, OpenCode
+- **Why chosen:** 7 specialized modules (do, omo, bmad, requirements, essentials, sparv, course). Two-tier architecture: Claude Code as orchestrator, codeagent-wrapper as executor. The bmad module brings 6 specialized agents for large-scale projects.
+- **What sets it apart:** Cross-tool orchestration — works across Claude Code, Codex, Gemini, and OpenCode simultaneously.
+- [github.com/stellarlinkco/myclaude](https://github.com/cexll/myclaude)
+
+### 16. cc-sessions (GWUDCAP) (1.5K stars)
+- **What:** Opinionated extension set — hooks, subagents, commands, task/git management infrastructure
+- **Why chosen:** Solves key pain points: tasks don't survive restarts, no confidence work continues across context windows, git workflow friction. Structured session management that persists.
+- **What sets it apart:** Solves the session persistence problem — the single biggest UX pain point in agentic coding.
+- [github.com/GWUDCAP/cc-sessions](https://github.com/GWUDCAP/cc-sessions)
+
+### 17. Claude Code Workflows (shinpr)
+- **What:** Production-ready development workflows with specialized AI agents
+- **Why chosen:** Enforced best practices, automated quality checks (tests, types, linting run automatically and get fixed if they fail). Complete lifecycle: requirements → implementation → review. Self-healing quality — if linting fails, the agent fixes it.
+- **What sets it apart:** Self-healing quality checks — the agent is its own QA department.
+- [github.com/shinpr/claude-code-workflows](https://github.com/shinpr/claude-code-workflows)
+
+### 18. wshobson/commands (1.7K stars)
+- **What:** Production-ready slash commands with multi-agent orchestration patterns
+- **Why chosen:** Workflows analyze requirements, delegate to specialized agents, coordinate execution. Clean, well-documented.
+- **What sets it apart:** Production-tested orchestration distilled into reusable slash commands.
+- [github.com/wshobson/commands](https://github.com/wshobson/commands)
+
+### 19. wshobson/agents
+- **What:** Intelligent automation and multi-agent orchestration for Claude Code
+- **Why chosen:** Companion to the commands repo — agent definitions that commands invoke. Together they form a complete orchestration system.
+- **What sets it apart:** Clean separation of concerns between agent definitions and command interfaces.
+- [github.com/wshobson/agents](https://github.com/wshobson/agents)
+
+---
+
+## CATEGORY 3: BMAD Method & Agile AI Workflows
+
+### 20. BMAD-AT-CLAUDE (24601)
+- **What:** Breakthrough Method for Agile AI-Driven Development ported to Claude Code
+- **Why chosen:** 26 specialized persona agents (Analyst, PM, Architect, Scrum Master, PO, Developer, QA). Each phase runs in a fresh chat to avoid context limitations. Handoffs between personas create versioned artifacts in git. Documentation as source of truth, not just code.
+- **What sets it apart:** The most structured approach to AI-assisted development — documentation as first-class artifacts.
+- [github.com/24601/BMAD-AT-CLAUDE](https://github.com/24601/BMAD-AT-CLAUDE)
+
+### 21. BMAD v6 + Langfuse + Claude Code Agent Teams (vadim.blog)
+- **What:** Production case study integrating BMAD v6 planning, Langfuse observability, Claude Code agent teams
+- **Why chosen:** Real production system (nomadically.work). Three pillars: planning/quality gates, observability, orchestration. Key warnings: Skip BMAD → agents produce code not matching requirements. Skip Langfuse → flying blind. Skip Agent Teams → merge conflicts.
+- **What sets it apart:** The only resource documenting a complete three-pillar production deployment with honest failure analysis.
+- [vadim.blog/bmad-langfuse-claude-code-agent-teams](https://vadim.blog/bmad-langfuse-claude-code-agent-teams)
+
+### 22. BMAD + Claude Flow + Gas Town Comparison (re:cinq)
+- **What:** Comparative analysis of three major orchestration frameworks
+- **Why chosen:** BMAD's planning runs ~3 hours before any code is written — significant upfront investment that pays off with predictable execution. Honest cost/benefit analysis.
+- **What sets it apart:** Real cost/time data on orchestration approaches (3 hours planning acknowledged).
+- [re-cinq.com/blog/multi-agent-orchestration-bmad-claude-flow-gastown](https://re-cinq.com/blog/multi-agent-orchestration-bmad-claude-flow-gastown)
+
+---
+
+## CATEGORY 4: Prompt Libraries & System Prompt Collections
+
+### 23. system-prompts-and-models-of-ai-tools (x1xhlol)
+- **What:** 30,000+ lines of system prompts from 30+ AI tools — Claude Code, Cursor, Devin, Lovable, Manus, Perplexity, Replit, Windsurf, and more
+- **Why chosen:** The definitive collection of how production AI tools instruct their models. Includes internal tools and model configurations. Essential for understanding how the best products engineer their prompts.
+- **What sets it apart:** Transparency into proprietary system prompts normally hidden. The most comprehensive reverse-engineering collection.
+- [github.com/x1xhlol/system-prompts-and-models-of-ai-tools](https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools)
+
+### 24. awesome-ai-system-prompts (dontriskit)
+- **What:** Curated collection with deep analysis of prompt engineering patterns
+- **Why chosen:** Highlights Manus's standout feature: explicitly defined operational loop (Analyze → Select Tool → Wait → Iterate → Submit → Standby). Analyzes patterns across ChatGPT, Claude, Perplexity, Grok, Notion, MetaAI.
+- **What sets it apart:** Not just collection but analysis — explains what makes each system prompt effective.
+- [github.com/dontriskit/awesome-ai-system-prompts](https://github.com/dontriskit/awesome-ai-system-prompts)
+
+### 25. awesome-system-prompts (EliFuzz)
+- **What:** System prompts and tool definitions from Augment Code, Claude Code, Cursor, Devin, Kiro, Perplexity, VSCode Agent, Gemini, Codex, OpenAI
+- **Why chosen:** Focuses on tool definitions alongside system prompts — shows not just what the AI is told, but what tools it's given.
+- **What sets it apart:** Tool definitions alongside prompts — the complete picture of agent capability design.
+- [github.com/EliFuzz/awesome-system-prompts](https://github.com/EliFuzz/awesome-system-prompts)
+
+### 26. agentic-system-prompts (tallesborges)
+- **What:** System prompts and tool definitions from production AI coding agents
+- **Why chosen:** Production-focused — actual prompts running in shipped products, not toy examples.
+- **What sets it apart:** Production provenance — every prompt from a real deployed system.
+- [github.com/tallesborges/agentic-system-prompts](https://github.com/tallesborges/agentic-system-prompts)
+
+### 27. agentic-prompts (jwadow)
+- **What:** Ready-to-use templates for prompt engineering, custom agent personas, AI-driven workflows
+- **Why chosen:** Expert project orchestrator persona that decomposes complex tasks and delegates to specialist agents. Optimized for Roo Code but adaptable.
+- **What sets it apart:** Persona-driven design — agents given identities and decision-making frameworks, not just tasks.
+- [github.com/jwadow/agentic-prompts](https://github.com/jwadow/agentic-prompts)
+
+---
+
+## CATEGORY 5: Cursor Rules & IDE Configurations
+
+### 28. awesome-cursorrules (PatrickJS)
+- **What:** Configuration files enhancing Cursor AI editor with custom rules and behaviors
+- **Why chosen:** The most popular .cursorrules collection. Covers Next.js, Unity/C#, web optimization, code pair interviews, Gherkin testing, documentation. Context awareness about project methods and architectural decisions.
+- **What sets it apart:** The OG cursorrules collection — largest community, most diverse framework coverage.
+- [github.com/PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules)
+
+### 29. awesome-ai-prompts (convertscout)
+- **What:** 206+ prompts, 500+ Cursor rules for React, Next.js, Python, Django
+- **Why chosen:** Includes a free prompt generator tool. Framework-specific rules for popular stacks.
+- **What sets it apart:** The prompt generator — a tool for creating new prompts, not just a static library.
+- [github.com/convertscout/awesome-ai-prompts](https://github.com/convertscout/awesome-ai-prompts)
+
+### 30. ai-prompts (instructa)
+- **What:** Curated prompts for Cursor Rules, Cline, Windsurf, and GitHub Copilot
+- **Why chosen:** Cross-platform rules that work across multiple AI IDEs. MIT licensed.
+- **What sets it apart:** Cross-tool compatibility — same rules across Cursor, Cline, Windsurf, Copilot.
+- [github.com/instructa/ai-prompts](https://github.com/instructa/ai-prompts)
+
+### 31. Cursor AI Prompting Rules (aashari gist)
+- **What:** Evidence-first prompting framework elevating AI to "Autonomous Principal Engineer"
+- **Why chosen:** Enforces rigorous workflow: reconnaissance, planning, safe execution, self-improvement. Not just rules but a complete engineering methodology.
+- **What sets it apart:** The "Principal Engineer" elevation — treats AI as a senior engineer with accountability.
+- [gist.github.com/aashari](https://gist.github.com/aashari/07cc9c1b6c0debbeb4f4d94a3a81339e)
+
+---
+
+## CATEGORY 6: GitHub Copilot Configurations & Agents
+
+### 32. awesome-copilot (github/awesome-copilot)
+- **What:** Official community-contributed instructions, prompts, and configurations for GitHub Copilot
+- **Why chosen:** Official GitHub repository. Includes Awesome Agents, Instructions, Hooks, Agentic Workflows, Skills. Works in CCA, VS Code, and Copilot CLI.
+- **What sets it apart:** Official GitHub backing — the canonical community resource.
+- [github.com/github/awesome-copilot](https://github.com/github/awesome-copilot)
+
+### 33. GitHub AGENTS.md Standard
+- **What:** Project instruction file shareable across Copilot, Claude Code, Cursor, Gemini CLI
+- **Why chosen:** Analysis of 2,500+ agents.md files shows best agents have: clear persona, executable commands, concrete code examples, explicit boundaries, tech stack specifics across 6 areas (commands, testing, project structure, code style, git workflow, boundaries).
+- **What sets it apart:** The emerging universal standard — works across all major AI tools.
+- [github.blog](https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/)
+
+### 34. GitHub Copilot Custom Instructions Hierarchy
+- **What:** Repository-wide and path-specific instruction files with agent scoping
+- **Why chosen:** Hierarchical system: Personal → Organization → Repository → Path-specific → Skills → AGENTS.md. New `excludeAgent` property controls which agents see which instructions. `applyTo` scopes rules to file patterns.
+- **What sets it apart:** Fine-grained scoping — different rules for different codebase areas and different agents.
+- [github.blog](https://github.blog/changelog/2025-11-12-copilot-code-review-and-coding-agent-now-support-agent-specific-instructions/)
+
+### 35. GitHub Agentic Workflows (Feb 13, 2026)
+- **What:** Automate repository tasks using AI agents in GitHub Actions, written in Markdown instead of YAML
+- **Why chosen:** Natural language workflows. AI handles issue triage, PR reviews, CI failure analysis. GitHub MCP Server integration + browser automation + web search. Open source MIT.
+- **What sets it apart:** Markdown-as-workflow — the most natural-language CI/CD automation approach.
+- [github.blog](https://github.blog/changelog/2026-02-13-github-agentic-workflows-are-now-in-technical-preview/)
+
+### 36. Copilot CLI (GA Feb 25, 2026)
+- **What:** Terminal agentic development environment with custom agents via .agent.md files
+- **Why chosen:** Plans, builds, reviews, remembers across sessions. Custom agents via interactive wizard or `.agent.md` files. Skills auto-load when relevant.
+- **What sets it apart:** Session memory — remembers across sessions, unlike most CLI tools.
+- [github.blog](https://github.blog/changelog/2026-02-25-github-copilot-cli-is-now-generally-available/)
+
+---
+
+## CATEGORY 7: Production Pipeline & Infrastructure Tools
+
+### 37. claude-code-router (25.3K stars)
+- **What:** Uses Claude Code as foundation for coding infrastructure — routes tasks to appropriate agents
+- **Why chosen:** Most-starred Claude Code ecosystem project. The router pattern applied to AI coding agents.
+- **What sets it apart:** Pure infrastructure — routing layer for agent task delegation.
+- [scriptbyai.com/claude-code-resource-list](https://www.scriptbyai.com/claude-code-resource-list/)
+
+### 38. claude-code-action (5.0K stars)
+- **What:** General-purpose Claude Code action for GitHub PRs and issues
+- **Why chosen:** Answers questions and implements code changes directly in GitHub. Bridges terminal power with GitHub collaboration.
+- **What sets it apart:** Native GitHub integration — Claude Code embedded in PR/issue workflows.
+- [scriptbyai.com/claude-code-resource-list](https://www.scriptbyai.com/claude-code-resource-list/)
+
+### 39. claude-code-spec-workflow (3.3K stars)
+- **What:** Automated Kiro-style Spec workflow: Requirements → Design → Tasks → Implementation
+- **Why chosen:** Transforms feature ideas into complete implementations through structured spec-driven process. Eliminates "just start coding" drift.
+- **What sets it apart:** Spec-first development automated end-to-end.
+- [scriptbyai.com/claude-code-resource-list](https://www.scriptbyai.com/claude-code-resource-list/)
+
+### 40. tdd-guard (1.7K stars)
+- **What:** Automated TDD enforcement for Claude Code
+- **Why chosen:** Prevents agents from writing code without tests. Makes test-driven development a hard constraint via hooks.
+- **What sets it apart:** TDD as infrastructure — physically impossible for agents to skip tests.
+- [github.com/jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code)
+
+### 41. CCPlugins (2.6K stars)
+- **What:** Claude Code Plugins focused on practical time savings
+- **Why chosen:** Community-validated, high star count. Explicit filter: "plugins that actually save time."
+- **What sets it apart:** Pragmatism as design principle.
+- [github.com/jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code)
+
+---
+
+## CATEGORY 8: Curated Awesome Lists & Meta-Resources
+
+### 42. awesome-claude-code (hesreallyhim)
+- **What:** Skills, hooks, slash-commands, agent orchestrators, applications, plugins
+- **Why chosen:** Agentic workflow patterns with Mermaid diagrams: Subagent Orchestration, Progressive Skills, Parallel Tool Calling, Master-Clone Architecture, Wizard Workflows. Highlights TÂCHES (meta-skills), Claude Code Infrastructure Showcase, Claude Code PM.
+- **What sets it apart:** Quality curation with architectural workflow documentation.
+- [github.com/hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
+
+### 43. awesome-claude-code (jqueryscript)
+- **What:** Curated list with star counts and categorization
+- **Why chosen:** Objective metrics. Easy scanning for popular and actively maintained projects.
+- **What sets it apart:** Quantitative curation — star counts for quick community validation.
+- [github.com/jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code)
+
+### 44. awesome-slash (avifenesh)
+- **What:** 11 plugins, 40 agents, 26 skills for Claude Code, OpenCode, Codex
+- **Why chosen:** "If static analysis, regex, or a shell command can do it, don't ask an LLM." Includes **agnix** — CLI + LSP linter with 155 rules catching config errors before they fail silently.
+- **What sets it apart:** "LLM-last" philosophy — deterministic tools first, LLM only when judgment is needed.
+- [github.com/avifenesh/awesome-slash](https://github.com/avifenesh/awesome-slash)
+
+### 45. awesome-agent-skills (heilcheng)
+- **What:** Skills, tools, tutorials for AI coding agents (Claude, Codex, Copilot, VS Code)
+- **Why chosen:** Cross-tool skills catalog with tutorials alongside definitions.
+- **What sets it apart:** Cross-platform skill portability documentation.
+- [github.com/heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills)
+
+### 46. The Ultimate Claude Code Resource List (scriptbyai.com)
+- **What:** Comprehensive web-based catalog of the Claude Code ecosystem
+- **Why chosen:** Star counts and links for every major project. Updated ~Feb 2026.
+- **What sets it apart:** Web-first presentation — easier to browse than GitHub READMEs.
+- [scriptbyai.com/claude-code-resource-list](https://www.scriptbyai.com/claude-code-resource-list/)
+
+### 47. 500-AI-Agents-Projects (ashishpatel26)
+- **What:** 500 AI agent use cases across healthcare, finance, education, retail
+- **Why chosen:** Largest single collection with implementation links. Organized by industry.
+- **What sets it apart:** Breadth across industries — business domain agents, not just coding.
+- [github.com/ashishpatel26/500-AI-Agents-Projects](https://github.com/ashishpatel26/500-AI-Agents-Projects)
+
+### 48. awesome-agentic-patterns (nibzard)
+- **What:** Agentic AI patterns — workflows, mini-architectures for production
+- **Why chosen:** Real-world patterns above individual tools, below full architectures. Framework-agnostic.
+- **What sets it apart:** Pattern-level thinking — transferable across any agent system.
+- [github.com/nibzard/awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns)
+
+---
+
+## CATEGORY 9: Enterprise Production Workflows
+
+### 49. Spotify "Honk" System
+- **What:** Internal AI deployment tool interfacing with Claude Code
+- **Why chosen:** 650+ AI-generated code changes shipped/month. ~50% of all updates flow through the system. Engineers deploy fixes via Slack from phones. 90% reduction in engineering time. Best developers haven't written code since Dec 2025.
+- **What sets it apart:** Scale — 50% of all updates at a major tech company flowing through AI agents.
+- [TechCrunch](https://techcrunch.com/2026/02/12/spotify-says-its-best-developers-havent-written-a-line-of-code-since-december-thanks-to-ai/)
+
+### 50. Shopify Sidekick Full-Stack Operator
+- **What:** AI-native commerce OS with agent write access to critical infrastructure
+- **Why chosen:** AI agents handle full commerce workflows. Sidekick gained write access — autonomous changes to production stores.
+- **What sets it apart:** Write access to production — agents modifying live infrastructure.
+- [shopify.com/news/winter-26-edition-dev](https://www.shopify.com/news/winter-26-edition-dev)
+
+---
+
+## CATEGORY 10: Official Best Practices & Methodology
+
+### 51. Anthropic Official Best Practices
+- **What:** Official CLAUDE.md, skills, hooks, and configuration guidance
+- **Why chosen:** Key principles: Keep CLAUDE.md short. For each line ask "Would removing this cause mistakes?" Bloated files cause Claude to ignore instructions. Use hooks for zero-exception requirements. Skills for on-demand knowledge. Treat CLAUDE.md like code.
+- **What sets it apart:** The authoritative source — everything else is interpretation.
+- [code.claude.com/docs/en/best-practices](https://code.claude.com/docs/en/best-practices)
+
+### 52. Builder.io CLAUDE.md Guide
+- **What:** Practical guide to CLAUDE.md authoring
+- **Why chosen:** Step-by-step from a team shipping production code with Claude Code daily. Example-driven.
+- **What sets it apart:** Production team's practical examples over abstract principles.
+- [builder.io/blog/claude-md-guide](https://www.builder.io/blog/claude-md-guide)
+
+### 53. GitHub "5 Tips for Better Custom Instructions"
+- **What:** Official Copilot instruction authoring guide
+- **Why chosen:** "Don't overthink it." Max 2 pages. Include app summary, tech stack, guidelines, structure. Use Copilot to bootstrap the file itself.
+- **What sets it apart:** The "don't overthink it" philosophy — refreshing simplicity.
+- [github.blog](https://github.blog/ai-and-ml/github-copilot/5-tips-for-writing-better-custom-instructions-for-copilot/)
+
+### 54. GitHub "How to Write a Great agents.md" (Feb 2026)
+- **What:** Data-driven lessons from 2,500+ repositories
+- **Why chosen:** Empirical. Best agents cover 6 areas: commands, testing, project structure, code style, git workflow, boundaries. Need executable commands and concrete examples.
+- **What sets it apart:** Recommendations backed by analysis of 2,500 real-world examples.
+- [github.blog](https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/)
+
+### 55. GitHub "Build Reliable AI Workflows with Agentic Primitives" (Feb 2026)
+- **What:** Methodology for reliable agentic workflows and context engineering
+- **Why chosen:** Introduces "agentic primitives" as building blocks and "context engineering" as a discipline. System-level design of agent information flows.
+- **What sets it apart:** Context engineering as a named discipline — the evolution beyond prompt engineering.
+- [github.blog](https://github.blog/ai-and-ml/github-copilot/how-to-build-reliable-ai-workflows-with-agentic-primitives-and-context-engineering/)
+
+---
+
+## CATEGORY 11: Advanced Patterns & Workflows
+
+### 56. Aircraft MRO System (100K+ lines via Claude Code)
+- **What:** 55 entities, 78 API endpoints, 114 UI components, generated in 20 hours
+- **Why chosen:** Most ambitious documented vibe coding project. ~50-60% AI-generated. Honest post-mortem: "Here's Why Vibe Coding Couldn't."
+- **What sets it apart:** Documents both successes and failures of vibe coding at scale.
+- [Medium](https://anil789.medium.com/we-built-a-100k-line-enterprise-app-using-ai-heres-why-vibe-coding-couldn-t-4f1220d08203)
+
+### 57. Adversarial Multi-Model Workflow
+- **What:** Same prompt across Claude, OpenAI, DeepSeek — agents critique each other's outputs
+- **Why chosen:** "Adversarial prompting" surfaces the best answers through competition. Used in production.
+- **What sets it apart:** Competition between models as a quality mechanism — AI peer review.
+- [InfoWorld](https://www.infoworld.com/article/4035926/multi-agent-ai-workflows-the-next-evolution-of-ai-coding.html)
+
+### 58. MetaGPT Team Simulation
+- **What:** LLM tools orchestrated into roles — PM, Architect, Engineer — with defined I/O per role
+- **Why chosen:** Addresses cascading errors through structured handoffs. Most complete team simulation.
+- **What sets it apart:** Full organizational structure, not just agents.
+- [pragmaticcoders.com](https://www.pragmaticcoders.com/resources/ai-developer-tools)
+
+### 59. Hooks Over Instructions (Trail of Bits philosophy)
+- **What:** Instructions are advisory; hooks are deterministic. Hooks for anything that must happen with zero exceptions.
+- **Why chosen:** Fundamental architectural insight separating robust setups from fragile ones.
+- **What sets it apart:** The foundational principle of reliable agent configuration.
+
+### 60. LLM-Last Design (awesome-slash philosophy)
+- **What:** Static analysis, regex, shell commands first. LLM only when judgment is needed.
+- **Why chosen:** Counter-intuitive but effective. Reduces cost, increases speed, improves reliability.
+- **What sets it apart:** Cost and reliability optimization through deterministic-first architecture.
+
+### 61. Progressive Disclosure via Skills
+- **What:** On-demand skill loading when context matches instead of bloating CLAUDE.md
+- **Why chosen:** Bloated CLAUDE.md causes instruction-ignoring. Skills provide knowledge only when relevant.
+- **What sets it apart:** "Less is more" applied to agent configuration.
+
+### 62. Session Persistence Patterns
+- **What:** Ledger files, handoff documents, git-based state tracking, checkpoint systems
+- **Why chosen:** Solves the biggest practical challenge: maintaining state across context windows and restarts.
+- **What sets it apart:** Addressing the fundamental limitation of context-window-bound agents.
+
+### 63. Spec-First Workflow
+- **What:** Requirements → Design → Tasks → Implementation as automated pipeline
+- **Why chosen:** Auditable artifacts at each stage. Each output feeds the next input.
+- **What sets it apart:** Structure where it helps, AI where it accelerates.
+
+### 64. Self-Healing Quality Checks
+- **What:** Tests/types/linting run automatically after changes — if they fail, the agent fixes them
+- **Why chosen:** Closes the loop between generation and validation. No human intervention for common issues.
+- **What sets it apart:** Autonomous quality — the agent is its own QA.
+
+---
+
+## Key Takeaways
+
+1. **Configuration is the new code.** CLAUDE.md, .cursorrules, agents.md are as important as source code itself.
+2. **Hooks > Instructions.** Deterministic hooks for hard requirements; instructions only for soft guidance.
+3. **Less CLAUDE.md is more.** Official recommendation: under 150 lines. Bloat causes instruction-ignoring.
+4. **Skills for progressive disclosure.** Context-matched on-demand loading beats front-loading everything.
+5. **Session persistence is the hard problem.** Most valuable tools solve state persistence across context windows.
+6. **Multi-agent orchestration is maturing.** Ruflo, BMAD, Claude Flow, myclaude converging on similar patterns.
+7. **Cross-tool standards are emerging.** AGENTS.md works across Copilot, Claude Code, Cursor, Gemini CLI.
+8. **Security scanning of configs is essential.** Agent configurations themselves are attack surfaces.
+9. **The "boring agents" win.** Narrow, specialized, deeply integrated > ambitious generalists.
+10. **Context engineering > prompt engineering.** Designing information flows across systems, not just individual prompts.


### PR DESCRIPTION
Two research documents covering 164 total entries:
- research-llm-agents-feb-2026.md: 100 state-of-the-art LLM agents, coding tools, frameworks, protocols, and production systems
- research-top-agent-toolkits-feb-2026.md: 64 top agent configuration suites, workflows, CLAUDE.md patterns, prompt libraries, orchestration systems, and production pipelines

Sources limited to GitHub, Substack, Medium, arXiv, and major tech publications.

https://claude.ai/code/session_01Urcwr1eTvgT9srZHZrQa1J