### PR TITLE
Fix 8 issues from PR #38 copilot review

### DIFF
--- a/admiral/hooks/engine.py
+++ b/admiral/hooks/engine.py
@@ -137,11 +137,25 @@ class HookEngine:
         for event in manifest.events:
             self._event_hooks[event].append(manifest.name)
 
-    def discover(self, hooks_dir: Path) -> list[str]:
+    def discover(
+        self,
+        hooks_dir: Path,
+        implementations_dir: Path | None = None,
+    ) -> list[str]:
         """Discover hooks from a directory tree.
 
         Looks for hook.manifest.json files in hooks_dir subdirectories.
-        Returns list of discovered hook names.
+        When a manifest directory contains no executable (e.g. aiStrat/
+        spec-only manifests), falls back to looking in implementations_dir
+        for a matching Python module.
+
+        Args:
+            hooks_dir: Root directory to search for hook.manifest.json files.
+            implementations_dir: Optional fallback directory containing hook
+                implementation scripts (e.g. admiral/hooks/implementations/).
+
+        Returns:
+            List of discovered hook names.
         """
         discovered = []
         if not hooks_dir.exists():
@@ -157,6 +171,22 @@ class HookEngine:
                 # Try any .py file in the directory
                 py_files = list(hook_dir.glob("*.py"))
                 executable = py_files[0] if py_files else None
+
+            # Fallback: look in the implementations directory
+            if executable is None and implementations_dir is not None:
+                impl_candidate = implementations_dir / f"{manifest.name}.py"
+                if impl_candidate.exists():
+                    executable = impl_candidate
+
+            if executable is None:
+                import warnings
+
+                warnings.warn(
+                    f"Hook '{manifest.name}' has a manifest at {manifest_path} "
+                    f"but no executable was found — skipping registration.",
+                    stacklevel=2,
+                )
+                continue
 
             self.register(
                 manifest=manifest,
@@ -225,33 +255,43 @@ class HookEngine:
         """Resolve hook execution order for an event using topological sort.
 
         Dependencies execute before dependents. Within the same dependency
-        level, hooks execute in registration order.
+        level, hooks execute in registration order (the order they were
+        appended to ``self._event_hooks[event]``).
         """
-        event_hooks = set(self._event_hooks.get(event, []))
+        registration_order = self._event_hooks.get(event, [])
+        event_hooks = set(registration_order)
         if not event_hooks:
             return []
 
-        # Topological sort (Kahn's algorithm)
+        # Build a position map so we can break ties by registration order
+        position = {name: idx for idx, name in enumerate(registration_order)}
+
+        # Topological sort (Kahn's algorithm) — ties broken by registration order
         in_degree: dict[str, int] = {name: 0 for name in event_hooks}
         for name in event_hooks:
             for dep in self._hooks[name].manifest.requires:
                 if dep in event_hooks:
                     in_degree[name] += 1
 
-        queue = sorted(
-            [name for name, deg in in_degree.items() if deg == 0]
-        )
-        order = []
+        queue = [name for name in registration_order if in_degree[name] == 0]
+        order: list[str] = []
 
         while queue:
             node = queue.pop(0)
             order.append(node)
-            for name in sorted(event_hooks):
-                if node in self._hooks[name].manifest.requires:
+            for name in registration_order:
+                if name in event_hooks and node in self._hooks[name].manifest.requires:
                     in_degree[name] -= 1
                     if in_degree[name] == 0:
-                        queue.append(name)
-                        queue.sort()
+                        # Insert into queue maintaining registration order
+                        inserted = False
+                        for i, q_name in enumerate(queue):
+                            if position[name] < position[q_name]:
+                                queue.insert(i, name)
+                                inserted = True
+                                break
+                        if not inserted:
+                            queue.append(name)
 
         return order
 
@@ -340,10 +380,17 @@ class HookEngine:
                     duration_ms=(time.monotonic() - start) * 1000,
                 )
 
-        # Subprocess execution
+        # Subprocess execution — select interpreter based on file extension.
+        # Supports the hook contract: "any executable (shell, Python, compiled binary)".
+        hook_path = str(hook.executable_path)
+        if hook_path.endswith(".py"):
+            cmd = [sys.executable, hook_path]
+        else:
+            cmd = [hook_path]
+
         try:
             proc = subprocess.run(
-                [sys.executable, str(hook.executable_path)],
+                cmd,
                 input=json.dumps(payload_with_event),
                 capture_output=True,
                 text=True,

--- a/admiral/hooks/implementations/context_baseline.py
+++ b/admiral/hooks/implementations/context_baseline.py
@@ -6,6 +6,10 @@ for comparison by context_health_check.
 
 From Section 08:
     Exit 0: baseline recorded. Stdout: initial context utilization metrics.
+
+Baseline data is returned on stdout for the runtime to persist and inject into
+future hook payloads (``hook_state.context_baseline``), rather than being stored
+in a module-level global that would be lost across subprocess invocations.
 """
 
 from __future__ import annotations
@@ -14,23 +18,27 @@ import json
 import sys
 from typing import Any
 
-# Module-level baseline storage (persists within session)
-_baseline: dict[str, Any] | None = None
+
+def get_baseline(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Get a previously recorded baseline from the runtime payload.
+
+    The runtime is expected to persist the baseline returned by ``execute()``
+    and inject it as ``payload["hook_state"]["context_baseline"]`` in later
+    hook invocations (e.g. context_health_check).
+    """
+    return payload.get("hook_state", {}).get("context_baseline")
 
 
-def get_baseline() -> dict[str, Any] | None:
-    """Get the recorded baseline (for context_health_check)."""
-    return _baseline
-
-
-def reset() -> None:
-    """Reset baseline (for testing or new sessions)."""
-    global _baseline
-    _baseline = None
+def reset() -> dict[str, Any]:
+    """Return an empty baseline state (for testing or new sessions)."""
+    return {}
 
 
 def execute(payload: dict[str, Any]) -> tuple[int, str, str]:
     """Execute the context baseline hook.
+
+    The computed baseline is returned on stdout as a JSON object containing
+    ``hook_state.context_baseline`` so the runtime can persist it.
 
     Args:
         payload: Hook input with context.standing_context_tokens and context.total_capacity.
@@ -38,8 +46,6 @@ def execute(payload: dict[str, Any]) -> tuple[int, str, str]:
     Returns:
         (exit_code, stdout, stderr)
     """
-    global _baseline
-
     context = payload.get("context", {})
     standing_tokens = context.get("standing_context_tokens", 0)
     total_capacity = context.get("total_capacity", 0)
@@ -49,14 +55,14 @@ def execute(payload: dict[str, Any]) -> tuple[int, str, str]:
 
     utilization = standing_tokens / total_capacity if total_capacity > 0 else 0.0
 
-    _baseline = {
+    baseline = {
         "standing_context_tokens": standing_tokens,
         "total_capacity": total_capacity,
         "initial_utilization": round(utilization, 4),
         "available_capacity": total_capacity - standing_tokens,
     }
 
-    return 0, json.dumps(_baseline), ""
+    return 0, json.dumps({"hook_state": {"context_baseline": baseline}, **baseline}), ""
 
 
 if __name__ == "__main__":

--- a/admiral/hooks/implementations/loop_detector.py
+++ b/admiral/hooks/implementations/loop_detector.py
@@ -6,6 +6,10 @@ Tracks (agent_id, error_signature) tuples and detects retry loops.
 From Section 08:
     Triggers when: same error recurs 3+ times, OR total retry count
     across all error signatures in a session exceeds configurable maximum (default: 10).
+
+State is carried via the runtime payload (``hook_state.loop_detector``) so that
+tracking survives subprocess invocations.  The runtime is responsible for
+persisting the returned state dict and injecting it into subsequent payloads.
 """
 
 from __future__ import annotations
@@ -15,20 +19,19 @@ import json
 import sys
 from typing import Any
 
-# Session-level state (persists across invocations within a session)
-_error_counts: dict[str, int] = {}
-_total_errors: int = 0
-_max_same_error: int = 3
-_max_total_errors: int = 10
+# Default thresholds
+_DEFAULT_MAX_SAME_ERROR: int = 3
+_DEFAULT_MAX_TOTAL_ERRORS: int = 10
 
 
-def reset(max_same: int = 3, max_total: int = 10) -> None:
-    """Reset loop detector state (for testing or new sessions)."""
-    global _error_counts, _total_errors, _max_same_error, _max_total_errors
-    _error_counts = {}
-    _total_errors = 0
-    _max_same_error = max_same
-    _max_total_errors = max_total
+def reset(max_same: int = 3, max_total: int = 10) -> dict[str, Any]:
+    """Return a fresh loop detector state dict (for testing or new sessions)."""
+    return {
+        "error_counts": {},
+        "total_errors": 0,
+        "max_same_error": max_same,
+        "max_total_errors": max_total,
+    }
 
 
 def _compute_signature(agent_id: str, error: str) -> str:
@@ -40,13 +43,23 @@ def _compute_signature(agent_id: str, error: str) -> str:
 def execute(payload: dict[str, Any]) -> tuple[int, str, str]:
     """Execute the loop detector hook.
 
+    State is read from ``payload["hook_state"]["loop_detector"]`` and the
+    updated state is returned as a JSON object on stdout so the runtime can
+    persist it for the next invocation.
+
     Args:
-        payload: Hook input with result.exit_code, result.error, agent_identity.
+        payload: Hook input with result.exit_code, result.error, agent_identity,
+                 and optionally hook_state.loop_detector.
 
     Returns:
         (exit_code, stdout, stderr)
     """
-    global _total_errors
+    # Recover persisted state from payload, or start fresh
+    hook_state = payload.get("hook_state", {}).get("loop_detector", {})
+    error_counts: dict[str, int] = dict(hook_state.get("error_counts", {}))
+    total_errors: int = hook_state.get("total_errors", 0)
+    max_same_error: int = hook_state.get("max_same_error", _DEFAULT_MAX_SAME_ERROR)
+    max_total_errors: int = hook_state.get("max_total_errors", _DEFAULT_MAX_TOTAL_ERRORS)
 
     result = payload.get("result", {})
     exit_code = result.get("exit_code", 0)
@@ -58,28 +71,46 @@ def execute(payload: dict[str, Any]) -> tuple[int, str, str]:
         return 0, "", ""
 
     sig = _compute_signature(agent_id, error_msg)
-    _error_counts[sig] = _error_counts.get(sig, 0) + 1
-    _total_errors += 1
-    count = _error_counts[sig]
+    error_counts[sig] = error_counts.get(sig, 0) + 1
+    total_errors += 1
+    count = error_counts[sig]
+
+    # Build updated state to return
+    updated_state = {
+        "error_counts": error_counts,
+        "total_errors": total_errors,
+        "max_same_error": max_same_error,
+        "max_total_errors": max_total_errors,
+    }
 
     # Check same-error threshold
-    if count >= _max_same_error:
-        message = (
-            f"Loop detected: error signature '{sig}' repeated {count} times. "
-            f"Moving to recovery ladder (Section 22)."
-        )
+    if count >= max_same_error:
+        message = json.dumps({
+            "loop_detected": True,
+            "reason": f"error signature '{sig}' repeated {count} times",
+            "message": (
+                f"Loop detected: error signature '{sig}' repeated {count} times. "
+                f"Moving to recovery ladder (Section 22)."
+            ),
+            "hook_state": {"loop_detector": updated_state},
+        })
         return 1, message, ""
 
     # Check total-error threshold
-    if _total_errors >= _max_total_errors:
-        message = (
-            f"Loop detected: total error count ({_total_errors}) exceeded "
-            f"session maximum ({_max_total_errors}). "
-            f"Moving to recovery ladder (Section 22)."
-        )
+    if total_errors >= max_total_errors:
+        message = json.dumps({
+            "loop_detected": True,
+            "reason": f"total error count ({total_errors}) exceeded session maximum ({max_total_errors})",
+            "message": (
+                f"Loop detected: total error count ({total_errors}) exceeded "
+                f"session maximum ({max_total_errors}). "
+                f"Moving to recovery ladder (Section 22)."
+            ),
+            "hook_state": {"loop_detector": updated_state},
+        })
         return 1, message, ""
 
-    return 0, "", ""
+    return 0, json.dumps({"hook_state": {"loop_detector": updated_state}}), ""
 
 
 if __name__ == "__main__":

--- a/admiral/hooks/self_healing.py
+++ b/admiral/hooks/self_healing.py
@@ -69,8 +69,8 @@ class SelfHealingLoop:
         key = f"{hook_name}:{signature}"
         self._total_retries += 1
 
-        # Check session-wide retry limit
-        if self._total_retries > self.max_session_retries:
+        # Check session-wide retry limit (hard cap, >= not >)
+        if self._total_retries >= self.max_session_retries:
             return SelfHealingResult(
                 should_retry=False,
                 message=(
@@ -82,10 +82,25 @@ class SelfHealingLoop:
                 hook_retries=self._records.get(key, RetryRecord(hook_name, signature)).count,
             )
 
-        # Check consecutive identical errors
+        # Early-exit: if the same error recurs immediately after a fix attempt
+        # (consecutive identical signature), break the loop right away per spec.
         if self._last_signature == signature and key in self._records:
             self._records[key].count += 1
-        elif key in self._records:
+            self._last_signature = signature
+            record = self._records[key]
+            return SelfHealingResult(
+                should_retry=False,
+                message=(
+                    f"Self-healing loop terminated: identical error recurred "
+                    f"after fix attempt (signature: {signature}). "
+                    f"Moving to recovery ladder step 2 (fallback)."
+                ),
+                total_retries=self._total_retries,
+                hook_retries=record.count,
+            )
+
+        # Track the error
+        if key in self._records:
             self._records[key].count += 1
         else:
             self._records[key] = RetryRecord(hook_name, signature)

--- a/admiral/models/handoff.py
+++ b/admiral/models/handoff.py
@@ -99,7 +99,7 @@ class HandoffDocument(BaseModel):
         alias="to",
         description="Receiving agent role.",
     )
-    via: str = Field(
+    via: HandoffVia = Field(
         ...,
         description="'Orchestrator' or 'Direct'.",
     )

--- a/admiral/tests/test_hooks.py
+++ b/admiral/tests/test_hooks.py
@@ -372,52 +372,63 @@ class TestTokenBudgetGate:
 @pytest.mark.phase1
 class TestLoopDetector:
     def setup_method(self):
-        loop_detector.reset()
+        self._state = loop_detector.reset()
+
+    def _make_payload(self, exit_code, error, agent_id="agent-1", state=None):
+        payload = {
+            "result": {"exit_code": exit_code, "error": error},
+            "agent_identity": agent_id,
+            "hook_state": {"loop_detector": state or self._state},
+        }
+        return payload
+
+    def _update_state(self, stdout):
+        """Extract updated state from hook stdout."""
+        if stdout:
+            import json
+            data = json.loads(stdout)
+            hs = data.get("hook_state", {}).get("loop_detector")
+            if hs:
+                self._state = hs
 
     def test_no_error_passes(self):
-        code, stdout, stderr = loop_detector.execute({
-            "result": {"exit_code": 0, "error": ""},
-            "agent_identity": "agent-1",
-        })
+        code, stdout, stderr = loop_detector.execute(
+            self._make_payload(0, "")
+        )
         assert code == 0
 
     def test_repeated_errors_detected(self):
         for _ in range(2):
-            code, _, _ = loop_detector.execute({
-                "result": {"exit_code": 1, "error": "TypeError: foo is not a function"},
-                "agent_identity": "agent-1",
-            })
+            code, stdout, _ = loop_detector.execute(
+                self._make_payload(1, "TypeError: foo is not a function")
+            )
             assert code == 0
+            self._update_state(stdout)
 
-        code, stdout, _ = loop_detector.execute({
-            "result": {"exit_code": 1, "error": "TypeError: foo is not a function"},
-            "agent_identity": "agent-1",
-        })
+        code, stdout, _ = loop_detector.execute(
+            self._make_payload(1, "TypeError: foo is not a function")
+        )
         assert code == 1
         assert "Loop detected" in stdout
 
     def test_total_error_threshold(self):
-        loop_detector.reset(max_same=100, max_total=5)
+        self._state = loop_detector.reset(max_same=100, max_total=5)
         for i in range(4):
-            code, _, _ = loop_detector.execute({
-                "result": {"exit_code": 1, "error": f"Different error {i}"},
-                "agent_identity": "agent-1",
-            })
+            code, stdout, _ = loop_detector.execute(
+                self._make_payload(1, f"Different error {i}")
+            )
             assert code == 0
+            self._update_state(stdout)
 
-        code, stdout, _ = loop_detector.execute({
-            "result": {"exit_code": 1, "error": "Yet another error"},
-            "agent_identity": "agent-1",
-        })
+        code, stdout, _ = loop_detector.execute(
+            self._make_payload(1, "Yet another error")
+        )
         assert code == 1
         assert "total error count" in stdout.lower()
 
 
 @pytest.mark.phase1
 class TestContextBaseline:
-    def setup_method(self):
-        context_baseline.reset()
-
     def test_records_baseline(self):
         code, stdout, stderr = context_baseline.execute({
             "context": {
@@ -426,10 +437,17 @@ class TestContextBaseline:
             }
         })
         assert code == 0
-        baseline = context_baseline.get_baseline()
+        import json
+        data = json.loads(stdout)
+        baseline = data.get("hook_state", {}).get("context_baseline")
         assert baseline is not None
         assert baseline["initial_utilization"] == 0.1
         assert baseline["available_capacity"] == 180_000
+
+        # Verify get_baseline() can extract from a payload carrying the state
+        payload_with_state = {"hook_state": {"context_baseline": baseline}}
+        retrieved = context_baseline.get_baseline(payload_with_state)
+        assert retrieved == baseline
 
 
 @pytest.mark.phase1


### PR DESCRIPTION
- loop_detector: use payload-based state instead of module-level globals
  so state persists across subprocess invocations
- context_baseline: return baseline via hook_state in stdout for runtime
  persistence instead of storing in module global
- engine.discover(): handle manifest-only directories (aiStrat/) by
  accepting an implementations_dir fallback; warn and skip when no
  executable is found
- engine subprocess execution: select interpreter based on file extension
  instead of always assuming Python, honoring the hook contract
- engine.resolve_execution_order(): preserve registration order for
  same-dependency-level hooks instead of sorting alphabetically
- self_healing: fix off-by-one in session retry limit (> to >=)
- self_healing: add early-exit when identical error recurs immediately
  after a fix attempt (consecutive signature match)
- handoff.py: type HandoffDocument.via as HandoffVia enum instead of
  plain str to enforce schema compliance at validation time

https://claude.ai/code/session_01CABHNFGUb9LMhsYr8wb3hi