### PR TITLE
Add product strategy: Admiral as AI Work OS, not just governance

### DIFF
--- a/aiStrat/research/product-strategy-ai-work-os.md
+++ b/aiStrat/research/product-strategy-ai-work-os.md
@@ -1,0 +1,241 @@
+# Admiral Product Strategy: The AI Work OS Reframe
+
+**Date:** March 14, 2026
+**Status:** Strategic inflection point — category definition
+
+---
+
+## The Core Insight
+
+Admiral has been framed as **governance for AI agents**. That framing is accurate but limiting. The deeper truth embedded in the specification is:
+
+**Admiral is the operating system for AI work.**
+
+This is not a rebrand. It's a recognition that the 15,000+ lines of spec already describe something bigger than governance — they describe the full operational environment in which AI organizations function.
+
+---
+
+## Why the Reframe Matters
+
+### "Governance" Sounds Like Overhead
+
+When people hear governance, they think:
+- compliance
+- bureaucracy
+- policies
+- restrictions
+
+That triggers a predictable reaction: *"We'll worry about that later."*
+
+This slows adoption. It positions Admiral as something you add after you already have agents — which means competing for budget against internal scripts, ad hoc monitoring, and enterprise compliance systems already in place.
+
+### Operating Systems Are Infrastructure
+
+Operating systems exist **before** applications. Nobody asks "Do we need an OS yet?" — they assume one exists. If Admiral is framed as the runtime environment where AI workers operate, the adoption conversation changes from "do we need this?" to "which one do we use?"
+
+---
+
+## What the Spec Already Contains
+
+The reframe isn't aspirational — the spec already covers every function of an operating environment:
+
+| OS Function | Admiral Implementation | Spec Location |
+|---|---|---|
+| **Process execution** | Agent lifecycle, task routing, workflow decomposition | Parts 4 (Fleet), 6 (Execution) |
+| **Process scheduling** | Routing rules, model tier assignment, swarm patterns | Fleet routing-rules, model-tiers |
+| **Memory management** | Brain architecture — 5-level persistent semantic memory | Brain L1-L3 specs |
+| **Security & access control** | Zero-trust identity tokens, decision authority tiers, enforcement spectrum | Parts 3, 11 |
+| **Inter-process communication** | Interface contracts, agent-to-agent handoffs, A2A protocol layer | Fleet interface-contracts |
+| **File system / storage** | Institutional memory, context injection, ground truth management | Parts 2, 5, 8 |
+| **Monitoring & logging** | Fleet observability, cost tracking, failure mode catalog | Parts 7, 8, 9 |
+| **System administration** | Admiral role, self-calibration, multi-operator governance | Part 10 |
+| **Device drivers** | Model-agnostic abstraction layer, MCP integration | Parts 4, 11 |
+| **Boot sequence** | Progressive adoption levels (L1-L5), pre-flight checklist | Index, Appendices |
+
+Every function is already specified. The spec **is** an operating system specification. It just hasn't been positioned that way.
+
+---
+
+## The AI Workforce Mental Model
+
+The deepest idea running through Admiral's entire architecture:
+
+> **AI agents are not tools. They are actors performing work inside systems.**
+
+If that's true — and the February 2026 repricing confirms the market believes it — then organizations deploying agents need:
+
+| Need | Traditional OS Equivalent | Admiral Equivalent |
+|---|---|---|
+| Supervision | Process monitoring | Fleet observability, governance agents |
+| Coordination | IPC, scheduling | Routing rules, interface contracts, swarm patterns |
+| Observability | System logs, traces | Brain queries, cost tracking, failure mode detection |
+| Enforcement | Permissions, access control | Enforcement spectrum, standing orders, decision authority |
+| Memory | File system, databases | Brain (L1-L5), institutional knowledge |
+| Identity | User accounts, auth | Identity tokens, zero-trust verification |
+| Recovery | Error handling, restart | Recovery ladder (retry → fallback → backtrack → isolate → escalate) |
+
+---
+
+## Strategic Implications
+
+### Category Changes
+
+| If Admiral is... | Competes with... | Category size |
+|---|---|---|
+| AI governance software | Internal scripts, compliance tools, ad hoc monitoring | Small, fragmented |
+| AI Work OS | Kubernetes, Linux, AWS | Infrastructure-scale |
+
+### Adoption Narrative Changes
+
+| Governance framing | OS framing |
+|---|---|
+| "You should add governance to your agents" | "Your AI workforce needs an operating environment" |
+| Optional, added later | Foundational, assumed from day one |
+| Cost center | Infrastructure investment |
+| Compliance-driven | Operations-driven |
+| Defensive posture | Enabling posture |
+
+### The Enabling Posture Is Key
+
+The single most important shift: an OS doesn't just restrict — it **enables**. Linux doesn't exist to prevent programs from misbehaving (though it does that). It exists to make programs possible in the first place.
+
+Admiral should be positioned the same way: the system that **makes it possible** to run AI workers at scale, not the system that **restricts** them.
+
+---
+
+## Category Names to Test
+
+In order of specificity:
+
+1. **AI Operations Infrastructure** — broadest, safest, most enterprise-friendly
+2. **AI Workforce Operating System** — most evocative, highest ambition, hardest to deliver
+3. **Agent Control Plane** — most technical, resonates with Kubernetes-native audience
+4. **AI Work OS** — shortest, catchiest, best for shorthand
+
+Recommendation: use **"Agent Control Plane"** in technical contexts (it's precise and developers already understand control planes from Kubernetes). Use **"AI Work OS"** in business contexts (it's evocative and immediately understood). Use **"AI Operations Infrastructure"** in enterprise sales (it's safe and budget-friendly).
+
+---
+
+## The Wedge Strategy
+
+### The Strategic Bet
+
+> If agent systems scale, Admiral becomes necessary.
+
+The smart move is to design the product so it is **still useful before that future fully arrives.** That's why the wedge matters:
+
+### Phase 1: Observability & Control Plane (Now)
+
+Even teams running a single agent need:
+- Trace what happened and why
+- Stop runaway execution
+- Understand cost
+- Debug failures
+
+This is immediately useful. No fleet required. No philosophical buy-in needed. Just "I deployed an agent and I need to see what it's doing."
+
+Admiral Level 1 already serves this use case. The spec's enforcement spectrum, standing orders, and failure mode catalog are valuable for a single agent.
+
+### Phase 2: Fleet Coordination (When teams scale to 3-10 agents)
+
+Routing, role boundaries, interface contracts, context management. The moment you have more than one agent, you need coordination primitives.
+
+Admiral Levels 2-3 serve this.
+
+### Phase 3: Full Operating Environment (When organizations go AI-native)
+
+Institutional memory, governance agents, adversarial defense, multi-operator coordination, cross-fleet federation.
+
+Admiral Levels 4-5 serve this.
+
+### Why This Works
+
+Each phase is useful **on its own merits**. Nobody needs to believe in the AI-native organization future to adopt Phase 1. But once they're on the platform, they naturally progress as their agent usage scales.
+
+This is the Kubernetes playbook: start with container orchestration for one service, end up running your entire infrastructure on it.
+
+---
+
+## What Changes in the Spec
+
+The reframe doesn't require rewriting the specification. It requires:
+
+### 1. Positioning Updates
+
+- **sales-pitch-30min-guide.md**: Reframe from "governance framework" to "operating system for AI work" with governance as one of five pillars (execution, observability, safety, coordination, memory)
+- **competitive-positioning-strategy.md**: Add new section on category definition — Admiral isn't competing with governance tools, it's defining AI operations infrastructure
+- **AGENTS.md / index.md**: Update the opening description from governance-first to OS-first language
+
+### 2. Structural Emphasis
+
+The spec's 11 parts already cover everything. But the current ordering emphasizes governance:
+
+```
+Current emphasis:    Strategy → Context → Enforcement → Fleet → Brain → Execution → Quality → Operations → Platform → Admiral → Protocols
+```
+
+For the OS framing, the natural emphasis becomes:
+
+```
+OS emphasis:         Execution → Fleet → Brain → Observability → Enforcement → Quality → Strategy → Context → Admiral → Protocols
+```
+
+This doesn't mean reordering the parts (that would break all cross-references). It means that **introductory materials, sales pitches, and adoption guides** should lead with execution and observability, not governance and enforcement.
+
+### 3. New Vocabulary Layer
+
+Add these terms to the glossary in `index.md`:
+
+| Term | Definition |
+|---|---|
+| **AI Work OS** | The complete operating environment for AI agent execution, coordination, observability, enforcement, and institutional memory |
+| **Control Plane** | The layer that manages agent lifecycle, routing, authority, and policy — distinct from the data plane where agents perform actual work |
+| **Data Plane** | The execution layer where agents perform tasks — managed by but separate from the control plane |
+| **Runtime Environment** | The configured context (standing orders, hooks, model assignments, Brain access) in which an individual agent operates |
+
+---
+
+## The Critical Question
+
+The conversation that produced this reframe ended with an implicit challenge:
+
+> Is Admiral a side project or a company?
+
+The answer depends on one thing: **whether Sean builds the reference implementation.**
+
+A specification without implementation is an academic contribution. A specification with a reference implementation is a platform. The difference between POSIX (an important standard few people think about) and Linux (a world-changing operating system) is that Linus shipped a kernel.
+
+Admiral's next phase should be:
+
+1. **Ship the control plane** — a minimal runtime that implements Standing Orders, the enforcement spectrum, and fleet observability for a single agent on Claude Code
+2. **Prove the wedge** — show that observability and control are immediately useful, before fleet governance matters
+3. **Let the spec pull adoption** — teams that adopt the control plane will discover they need the rest of the spec as they scale
+
+The specification is complete enough. The strategic framing is now clear. The next move is implementation.
+
+---
+
+## Relationship to Existing Strategy Documents
+
+This document extends and partially supersedes:
+
+- **sales-pitch-30min-guide.md** — The pitch should be updated to lead with the OS framing. The governance pitch becomes section 2, not section 1.
+- **competitive-positioning-strategy.md** — The "hold firm" positions remain unchanged. The "adopt" and "work with" sections gain new context: Admiral isn't just governance that complements agent platforms — it's the operating layer they all need.
+- **monetizing-doctrine-playbook.md** — The OS framing opens new monetization paths: hosted control plane (SaaS), enterprise runtime (on-prem), certification program (training), marketplace (agent definitions).
+
+---
+
+## Summary
+
+| Before | After |
+|---|---|
+| Admiral is governance for AI agents | Admiral is the operating system for AI work |
+| Governance is the product | Governance is one of five OS functions |
+| Competes with compliance tools | Defines a new infrastructure category |
+| Adopted when governance becomes required | Adopted when AI agents are deployed |
+| Defensive: "prevent bad things" | Enabling: "make AI work possible at scale" |
+| The spec is the product | The spec is the blueprint; the runtime is the product |
+
+The specification was always building toward this. The 11 parts, 71 agent roles, Brain architecture, enforcement spectrum, and progressive adoption model aren't a governance framework — they're an operating system specification that's been called a governance framework.
+
+Time to call it what it is.


### PR DESCRIPTION
Captures the category-defining reframe from "governance for AI agents"
to "operating system for AI work." Maps existing spec to OS functions,
defines wedge strategy (observability → fleet coordination → full OS),
and identifies the critical next move: ship the reference implementation.

https://claude.ai/code/session_01GFKjJSjpi9PTpX5x2gUSJj