### PR TITLE
Add Anthropic Academy analysis to competitive landscape and monetization playbook

### DIFF
--- a/aiStrat/research/competitive-landscape-2026.md
+++ b/aiStrat/research/competitive-landscape-2026.md
@@ -306,6 +306,26 @@ These aren't competitors but foundational standards that affect Admiral's positi
 
 **Implication for Admiral:** MCP standardizes the *tool connection* layer. Admiral should position as the *governance* layer that sits above MCP — defining what tools agents are allowed to use and under what authority, not just how they connect.
 
+### Anthropic Academy (Launched March 2, 2026)
+
+- **13 free courses** with certificates hosted on Skilljar ([anthropic.skilljar.com](https://anthropic.skilljar.com))
+- Three tracks: **AI Fluency** (Claude 101, educator/student/nonprofit tracks), **Developer Deep-Dives** (Claude Code, API, MCP, Agent Skills), **Product Training** (Amazon Bedrock, Google Vertex AI integration)
+- Key courses: Claude 101, Building with the Claude API (8+ hours), Introduction to MCP, Claude Code in Action (21 lessons), Introduction to Agent Skills
+- All courses are **completely free** with certificates that can be added to LinkedIn
+- No Anthropic account required — only a Skilljar account
+
+**Why this matters:** Anthropic is using education as an **ecosystem lock-in strategy**, not a revenue stream. By training developers for free on MCP, Agent Skills, and Claude API patterns, they're embedding Anthropic's vocabulary and architectural patterns as the default mental model for agent development. This is demand generation at scale — every developer who completes "Introduction to MCP" builds within Anthropic's ecosystem.
+
+**Implication for Admiral:** This is a two-sided threat and opportunity:
+- **Threat:** Anthropic is actively training developers on *their* agent architecture patterns (via the Agent Skills course). If their framing becomes the default vocabulary, Admiral's doctrine must either align with or explicitly differentiate from Anthropic's mental models.
+- **Opportunity:** The MCP and Agent Skills courses teach developers *how to build agents* but not *how to govern them*. Admiral's governance doctrine fills the gap that Anthropic's education leaves open — role architecture, decision authority, enforcement spectrum, and institutional memory are not covered.
+- **Strategic move:** Consider creating an Admiral-specific course track that positions as the "governance companion" to Anthropic Academy — "You learned to build agents with Anthropic. Now learn to govern them with Admiral."
+
+**Sources:**
+- [Anthropic Courses](https://anthropic.skilljar.com/)
+- [Top 7 Free Anthropic AI Academy Courses](https://www.analyticsvidhya.com/blog/2026/03/free-anthropic-ai-courses-with-certificates/)
+- [Anthropic Dropped 13 Free Courses — Breakdown](https://dev.to/ji_ai/anthropic-dropped-13-free-courses-i-broke-down-every-single-one-p87)
+
 ### Google's Agent-to-Agent Protocol (A2A)
 
 - Defines how agents from different vendors communicate with each other

--- a/aiStrat/research/monetizing-doctrine-playbook.md
+++ b/aiStrat/research/monetizing-doctrine-playbook.md
@@ -135,6 +135,18 @@ Based on these precedents, here's a layered approach — from fastest revenue to
 
 **The multiplier:** If even 1% of the estimated 2M+ professionals who'll be working with AI agents by 2028 get Admiral certified at $300 each, that's $6M in exam fees alone — before training partner revenue.
 
+> **⚠️ Market Signal: Anthropic Academy (March 2, 2026)**
+>
+> Anthropic launched **13 free courses with certificates** at [anthropic.skilljar.com](https://anthropic.skilljar.com), covering Claude API, MCP, Agent Skills, and Claude Code. All courses are completely free with LinkedIn-ready certificates. This represents a significant counter-data-point to the paid certification model:
+>
+> **What it means for Admiral's certification strategy:**
+> - **The "free vendor cert" precedent is now set.** Anthropic is using certifications as ecosystem demand-gen, not revenue. If developers expect AI certifications to be free, Admiral's paid tiers ($200-$800) need stronger justification.
+> - **Admiral certifies a different thing.** Anthropic's certs prove you can *use their tools*. Admiral's certs would prove you can *govern agent fleets* — a higher-order, vendor-neutral skill closer to ITIL/TOGAF than to a product tutorial. This distinction is critical to defend paid pricing.
+> - **Freemium hybrid may be necessary.** Consider: free Admiral Practitioner (like Anthropic's free certs — drives adoption and vocabulary spread) + paid Admiral Architect and ACI (where the governance depth justifies cost, similar to TOGAF's $495-$1,200 range).
+> - **Positioning matters.** Anthropic teaches "how to build." Admiral teaches "how to govern." These are complementary, not competitive — but only if Admiral's certification clearly occupies the governance/operations lane rather than the tools/API lane.
+>
+> **Sources:** [Anthropic Academy](https://anthropic.skilljar.com/) | [Course Breakdown](https://dev.to/ji_ai/anthropic-dropped-13-free-courses-i-broke-down-every-single-one-p87)
+
 ---
 
 ### Layer 4: Ecosystem Licensing (Revenue in 12-18 months)


### PR DESCRIPTION
Anthropic launched 13 free courses with certificates (March 2, 2026) at
anthropic.skilljar.com. This impacts Admiral's competitive positioning and
certification pricing strategy. Updates include:

- competitive-landscape-2026.md: New "Anthropic Academy" section under Protocol
  Layer covering the education-as-ecosystem-lock-in strategy and implications
  for Admiral's governance positioning
- monetizing-doctrine-playbook.md: Market signal callout in Layer 3
  (Certification) addressing the free-cert precedent and recommending a
  freemium hybrid model to remain competitive

https://claude.ai/code/session_01CZ3yJmg5jQqXZxnF3uqWAZ