### PR TITLE
docs: resolve version inconsistencies, narrative contradictions, and spec debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Spec reference: `aiStrat/admiral/spec/part11-protocols.md`
 
 ## Boundaries
 
-- Do NOT modify spec files in `aiStrat/` without explicit approval (spec is frozen at v0.5.3-alpha)
+- Do NOT modify spec files in `aiStrat/` without explicit approval
 - Do NOT add runtime dependencies to control-plane (zero-dependency policy)
 - Do NOT store secrets, credentials, or PII in any file
 - Do NOT modify `.github/workflows/` without approval
@@ -63,5 +63,3 @@ Spec reference: `aiStrat/admiral/spec/part11-protocols.md`
 - Hook contracts: `aiStrat/admiral/spec/part3-enforcement.md`
 - Brain entry format: `aiStrat/brain/level1-spec.md`
 - Standing Orders text: `aiStrat/admiral/spec/part11-protocols.md`
-- Implementation plan: `PLAN.md` (phases, scope, exit criteria)
-- Detailed plan: `PLAN2.md` (task decomposition, dependency graph)

--- a/aiStrat/admiral/extensions/thesis.md
+++ b/aiStrat/admiral/extensions/thesis.md
@@ -73,4 +73,4 @@ Admiral is what makes it safe to run AI agents as a workforce instead of using t
 
 ---
 
-*Full analysis: [research/future-operations.md](../../../research/future-operations.md)*
+*Full analysis: `research/future-operations.md` (external reference — lives outside the spec boundary in the homebase repo root)*

--- a/aiStrat/admiral/reference/benchmarks.md
+++ b/aiStrat/admiral/reference/benchmarks.md
@@ -2,6 +2,8 @@
 
 > **Audience:** Implementers and evaluators measuring Admiral Framework effectiveness. These benchmarks define what "good" looks like for an Admiral-governed fleet.
 
+> **Maturity Note:** All targets in this document are hypothetical until validated through real-world deployment. Targets are informed estimates based on software engineering heuristics and analogous systems — not empirical measurements from Admiral-governed fleets. As real-world data becomes available, targets should be updated and marked as validated.
+
 -----
 
 ## Core Metrics
@@ -107,9 +109,9 @@ These are capabilities unique to or pioneered by the Admiral Framework:
 
 These are order-of-magnitude expectations, not guarantees. Actual performance depends on domain, model selection, and implementation quality.
 
-| Phase | Governance Overhead | First-Pass Quality | Recovery Rate | Enforcement Coverage |
-|---|---|---|---|---|
-| Initial deployment | 20-30% | 50-60% | 60-70% | 27% (4/15) |
-| After 2 weeks | 15-20% | 65-75% | 75-85% | 50%+ (target) |
-| After 3 months | 10-15% | 75-85% | 85-95% | 80%+ (target) |
-| Mature fleet | < 10% | > 85% | > 95% | > 90% |
+| Phase | Governance Overhead | First-Pass Quality | Recovery Rate | Enforcement Coverage | Basis | Validated |
+|---|---|---|---|---|---|---|
+| Initial deployment | 20-30% | 50-60% | 60-70% | 27% (4/15) | Informed estimate from analogous systems | Not yet |
+| After 2 weeks | 15-20% | 65-75% | 75-85% | 50%+ (target) | Informed estimate | Not yet |
+| After 3 months | 10-15% | 75-85% | 85-95% | 80%+ (target) | Informed estimate | Not yet |
+| Mature fleet | < 10% | > 85% | > 95% | > 90% | Informed estimate | Not yet |

--- a/aiStrat/admiral/reference/spec-debt.md
+++ b/aiStrat/admiral/reference/spec-debt.md
@@ -1,0 +1,72 @@
+# Specification Debt
+
+> **Audience:** Spec authors and reviewers. This document tracks known areas where the Admiral Framework specification is aspirational rather than validated, where claims outpace evidence, or where internal consistency could be improved. Modeled after `spec-gaps.md`, which successfully tracked and resolved 14 vague behavioral claims.
+>
+> **Update policy:** Add entries when gaps are discovered. Resolve entries when evidence is provided or spec language is adjusted to match reality. Keep resolved entries as historical records.
+
+-----
+
+## Active Debt
+
+### SD-01: Hook Coverage vs. Enforcement Spectrum Thesis
+
+**Severity:** High
+**Claim:** The enforcement spectrum (hooks over instructions) is Admiral's core differentiator. The thesis and sales pitch present deterministic enforcement as the defining advantage.
+**Reality:** Only 4 of 15 Standing Orders (27%) have hook enforcement. The remaining 73% are enforced only by instructions — the exact mechanism the framework argues is unreliable.
+**Where it appears:** `thesis.md`, `sales-pitch-30min-guide.md`, `part3-enforcement.md`
+**Acknowledged in:** `benchmarks.md` ("Current state: 4/15 (27%)" with target of 80%+)
+**Resolution path:** Either increase hook coverage to a defensible percentage (target: 8/15 minimum) or adjust thesis language to acknowledge that the enforcement spectrum is a design principle with partial implementation, not a fully realized system.
+
+-----
+
+### SD-02: Benchmark Targets Lack Empirical Basis
+
+**Severity:** Moderate
+**Claim:** Benchmarks define targets (First-pass quality > 75%, Auto-recovery > 80%, etc.) and project improvement trajectories over time.
+**Reality:** All targets are informed estimates. No Admiral-governed fleet has produced empirical measurements.
+**Where it appears:** `benchmarks.md`
+**Resolution path:** Run end-to-end validation on a real project; populate the "Validated" column with actual measurements. Adjust targets if reality diverges from estimates.
+
+-----
+
+### SD-03: Fleet Catalog Presented as Differentiator Without Validation
+
+**Severity:** Moderate
+**Claim:** "71 pre-defined roles with interface contracts don't exist anywhere else" (sales pitch).
+**Reality:** Agent definitions are specifications based on production patterns, not battle-tested implementations (correctly acknowledged in `AGENTS.md`). External-facing documents present them as a competitive advantage without noting this caveat.
+**Where it appears:** `sales-pitch-30min-guide.md`
+**Resolution path:** Add a brief caveat in the sales pitch: "based on production patterns, refined through real-world deployment" — honest without undermining the differentiator claim.
+
+-----
+
+### SD-04: Monitor Immune System Layers 3-5 Are Specified But Unimplemented
+
+**Severity:** Moderate
+**Claim:** The Monitor has a five-layer immune system with deterministic semantic analysis, LLM advisory, and antibody learning.
+**Reality:** Only Layers 1-2 have partial implementation. Layers 3-5 are fully specified but have no code, pseudocode, or reference implementation.
+**Where it appears:** `monitor/README.md`
+**Resolution path:** Either write reference implementations (even pseudocode) for Layers 3-5, or adjust the specification to clearly mark them as "design intent" rather than "architecture specification."
+
+-----
+
+### SD-05: Data Ecosystem (Part 12) Is the Thinnest Doctrine Part
+
+**Severity:** Low (improved in v0.8.1)
+**Claim:** Part 12 defines a complete closed-loop data ecosystem with 6 feedback loops, 7 datasets, and 5 ecosystem agents.
+**Reality:** The ecosystem is well-specified at the conceptual level. Dataset record schemas and a worked example were added in v0.8.1. However, it remains the most abstract part of the doctrine — no reference implementations exist for any feedback loop or ecosystem agent.
+**Resolution path:** Continue deepening with additional worked examples. Validate at least one feedback loop end-to-end during real-world deployment.
+
+-----
+
+## Resolved Debt
+
+*(No entries yet. Move entries here when resolved, with resolution date and evidence.)*
+
+-----
+
+## Cross-References
+
+- Spec gap tracking (resolved): `spec-gaps.md`
+- Constants registry: `reference-constants.md`
+- Benchmarks: `benchmarks.md`
+- Enforcement mapping: `standing-orders-enforcement-map.md`

--- a/aiStrat/admiral/reference/spec-gaps.md
+++ b/aiStrat/admiral/reference/spec-gaps.md
@@ -1,6 +1,6 @@
 # Specification Gaps: Vague Behavioral Claims Needing Concrete Constants
 
-> **Status: ALL GAPS RESOLVED (v0.5.3-alpha).** All 14 gaps (7 Critical, 6 Moderate, 1 Minor) have been resolved with concrete thresholds added to their source spec files and mirrored in `reference-constants.md`. This document is retained as a historical record of the gaps and their resolutions.
+> **Status: ALL GAPS RESOLVED (v0.8.1-alpha).** All 14 gaps (7 Critical, 6 Moderate, 1 Minor) have been resolved with concrete thresholds added to their source spec files and mirrored in `reference-constants.md`. This document is retained as a historical record of the gaps and their resolutions.
 >
 > **Audience:** Spec authors and reviewers. This document identifies sections across the Admiral Framework that make behavioral claims without pinning down concrete numbers, thresholds, or constants. Each gap includes the vague phrase, what should be specified, and a suggested value inferred from context.
 
@@ -253,7 +253,7 @@
 ~~2. **Following minor (v0.6.0):** Resolve Moderate gaps #8–13 with quantitative thresholds.~~
 3. **Ongoing:** Establish a "no vague thresholds" lint rule for spec PRs — every behavioral claim must have a number or explicitly cite another document that provides one.
 
-> **Resolution note (v0.5.3-alpha):** All 14 gaps resolved. Concrete thresholds added to source spec files and mirrored in `reference-constants.md § Spec-Gap Resolved Thresholds`.
+> **Resolution note (v0.8.1-alpha):** All 14 gaps resolved. Concrete thresholds added to source spec files and mirrored in `reference-constants.md § Spec-Gap Resolved Thresholds`.
 
 -----
 

--- a/aiStrat/admiral/spec/index.md
+++ b/aiStrat/admiral/spec/index.md
@@ -2,7 +2,7 @@
 
 **A Workforce Toolkit for Autonomous AI Agent Fleets**
 
-v0.5.3-alpha · March 2026
+v0.8.1-alpha · March 2026
 
 -----
 
@@ -16,6 +16,20 @@ Pick the parts you need. A two-person team might use only the enforcement spectr
 
 -----
 
+## Framework Lenses
+
+Admiral is described through three different decompositions depending on context. These are complementary views of the same system, not competing taxonomies.
+
+| Lens | Count | Names | Used Where | Purpose |
+|---|---|---|---|---|
+| **Repository Pillars** | 3 | Doctrine (`admiral/`), Fleet (`fleet/`), Design Artifacts (`brain/`, `monitor/`) | AGENTS.md, README.md | Organizes the file structure — where things live |
+| **Pitch Pillars** | 5 | Role Architecture, Decision Authority & Enforcement, Visibility & Control Plane, Coordination & Execution, Institutional Memory (Brain) | Sales conversations, external communication | Explains what Admiral does — capability framing for non-technical audiences |
+| **Scaling Components** | 7 | Brain, Fleet, Enforcement, Control Plane, Security, Protocols, Data Ecosystem | Per-Component Scaling (below), Quick-Start Profiles | Defines what you deploy and at what level — the operational building blocks |
+
+The three Repository Pillars contain the seven Scaling Components. The five Pitch Pillars regroup the same capabilities for audience clarity. All three lenses describe the same framework.
+
+-----
+
 ## Thesis
 
 Admiral is **the operational infrastructure for AI workforces.**
@@ -26,7 +40,7 @@ Admiral enables a new form of organization: **the hybrid organization where AI a
 
 The new behavior Admiral enables: *treating AI capacity as an operational workforce, not a feature.*
 
-See [`thesis.md`](../extensions/thesis.md) for the full analysis and [`research/future-operations.md`](../../../research/future-operations.md) for the underlying thought experiment.
+See [`thesis.md`](../extensions/thesis.md) for the full analysis. *External reference: `research/future-operations.md` in the homebase repo root contains the underlying thought experiment.*
 
 -----
 

--- a/aiStrat/admiral/spec/part12-data-ecosystem.md
+++ b/aiStrat/admiral/spec/part12-data-ecosystem.md
@@ -645,6 +645,140 @@ Each dataset follows a lifecycle that ensures freshness and prevents unbounded g
 | Operational Genome | 1 hour | Operational event stream | Alert Ecosystem Health Monitor |
 | Cross-Domain Insight Graph | 24 hours | Scheduled graph computation | Recompute from component datasets |
 
+### Dataset Record Schemas
+
+The four data streams (above) define event-level schemas for raw capture. The seven proprietary datasets aggregate, enrich, and link those events into higher-order records. Below are schemas for the two most strategically valuable datasets — the Decision Registry and the Outcome Ledger — which together form the backbone of outcome attribution.
+
+**Decision Registry Record:**
+
+```json
+{
+  "decision_id": "uuid",
+  "recorded_at": "ISO-8601",
+  "agent_id": "string",
+  "session_id": "string",
+  "project": "string",
+  "decision": {
+    "summary": "string",
+    "category": "architecture | implementation | configuration | routing | escalation | other",
+    "alternatives_considered": ["string"],
+    "chosen_alternative": "string",
+    "rationale": "string",
+    "confidence": "float (0.0-1.0)"
+  },
+  "authority": {
+    "tier_used": "autonomous | propose | escalate",
+    "approval_required": "boolean",
+    "approved_by": "string | null",
+    "approval_latency_ms": "int | null"
+  },
+  "context_consumed": {
+    "brain_entries_consulted": ["uuid"],
+    "standing_context_tokens": "int",
+    "working_context_tokens": "int"
+  },
+  "outcome_link": {
+    "outcome_id": "uuid | null",
+    "attribution_confidence": "float | null",
+    "attribution_type": "direct | temporal | semantic | null"
+  },
+  "resource_cost": {
+    "tokens_input": "int",
+    "tokens_output": "int",
+    "model_tier": "tier1 | tier2 | tier3",
+    "cost_usd": "float"
+  }
+}
+```
+
+**Outcome Ledger Record:**
+
+```json
+{
+  "outcome_id": "uuid",
+  "recorded_at": "ISO-8601",
+  "outcome_type": "customer_success | customer_failure | operational_improvement | operational_regression | neutral",
+  "source_stream": "engagement | trend | agent_output | operational",
+  "description": "string",
+  "metrics": {
+    "primary_metric": "string",
+    "primary_value": "float",
+    "baseline_value": "float",
+    "delta_pct": "float"
+  },
+  "attribution": {
+    "decision_ids": ["uuid"],
+    "attribution_method": "direct | temporal | semantic",
+    "confidence": "float (0.0-1.0)",
+    "attribution_lag_hours": "float"
+  },
+  "brain_impact": {
+    "entries_strengthened": ["uuid"],
+    "entries_superseded": ["uuid"],
+    "entries_created": ["uuid"]
+  }
+}
+```
+
+### Worked Example: Agent Calibration Loop (Loop 1)
+
+This example traces a complete rotation of Loop 1 — from agent decision through customer outcome to trust calibration adjustment.
+
+**Step 1: Agent Decision.** The Backend Implementer agent (Agent ID: `backend-impl`) is assigned a database migration task. It consults the Brain, finds 3 relevant entries about the project's migration patterns, and decides to use a zero-downtime migration strategy. Confidence: 0.88. Authority tier: Autonomous.
+
+```
+Decision Registry entry created:
+  decision_id: "d-4a7f..."
+  agent_id: "backend-impl"
+  decision.summary: "Use zero-downtime migration with shadow table strategy"
+  decision.confidence: 0.88
+  authority.tier_used: "autonomous"
+  context_consumed.brain_entries_consulted: ["b-112...", "b-347...", "b-891..."]
+```
+
+**Step 2: Outcome Observation.** 48 hours later, operational monitoring shows the migration completed with zero downtime and no data integrity issues. The QA Agent confirms all post-migration tests pass. An engagement event shows no customer-reported issues.
+
+```
+Outcome Ledger entry created:
+  outcome_id: "o-8c3e..."
+  outcome_type: "operational_improvement"
+  description: "Zero-downtime migration completed successfully, 0 data integrity issues, 0 customer reports"
+  metrics.primary_metric: "downtime_seconds"
+  metrics.primary_value: 0
+  metrics.baseline_value: 120 (previous migration average)
+```
+
+**Step 3: Attribution.** The Attribution Engine links the outcome to the decision. The temporal window (48 hours) and direct task relationship yield high confidence.
+
+```
+Outcome Ledger updated:
+  attribution.decision_ids: ["d-4a7f..."]
+  attribution.method: "direct"
+  attribution.confidence: 0.95
+  attribution.lag_hours: 48
+
+Decision Registry updated:
+  outcome_link.outcome_id: "o-8c3e..."
+  outcome_link.attribution_confidence: 0.95
+  outcome_link.attribution_type: "direct"
+```
+
+**Step 4: Brain Strengthening.** The 3 Brain entries that informed the decision are strengthened (usefulness scores increase). The decision itself is recorded as a new Brain `decision` entry with a positive outcome link.
+
+**Step 5: Feedback Synthesis.** The Feedback Synthesizer observes that `backend-impl` has now made 6 consecutive successful Autonomous decisions in the "database-migration" category (threshold: 5). It generates a calibration recommendation:
+
+```
+Recommendation: Expand backend-impl Autonomous tier
+  Category: database-migration
+  Evidence: 6/6 successful outcomes, mean confidence 0.85, 0 escalations
+  Proposed change: Promote "schema-change" decisions from Propose → Autonomous
+    (currently backend-impl must propose schema changes for Admiral approval)
+```
+
+**Step 6: Admiral Review.** The Admiral reviews the recommendation, approves the trust expansion. `backend-impl` now has Autonomous authority for schema changes in the database-migration category. The Calibration History dataset records the change with full evidence chain.
+
+**Loop complete.** The fleet is now slightly more autonomous in an area where it has demonstrated competence. The next rotation will test whether this expanded autonomy produces good outcomes — if it does, trust compounds further. If it doesn't, the counter resets.
+
 ### Data Retention & Compliance
 
 All datasets operate under the Data Sensitivity Protocol (Data Sensitivity Classification, Part 11):

--- a/aiStrat/fleet/agents/extras/scale-extended.md
+++ b/aiStrat/fleet/agents/extras/scale-extended.md
@@ -4,6 +4,8 @@ These are supplementary inhuman-scale analysis agents held in reserve for refere
 
 Deploy these when a specific review cycle requires analysis dimensions beyond what the core scale agents cover. Most projects will never need all 17 — select 1-3 based on the fleet's current phase and concerns.
 
+> **Maturity: Exploratory** — These extended scale agents have not been validated in production deployments. They are included to illustrate the range of agent-addressable analysis, not as proven operational patterns.
+
 **Maturity Note:** These extended scale agents range from immediately practical to exploratory. 8 of 17 agents are marked [Exploratory] — they depend on data sources or reasoning capabilities that may exceed current LLM reliability. Deploy exploratory agents in advisory-only mode with human review of all findings. The remaining 9 agents are immediately practical and can be deployed with standard governance.
 
 Extended scale agents should follow the cross-cutting standards defined in `scale.md` (common output schema, confidence calibration, audit logging, read-only access, no secrets handling).

--- a/aiStrat/fleet/agents/scale.md
+++ b/aiStrat/fleet/agents/scale.md
@@ -2,6 +2,8 @@
 
 **Category:** Scale
 
+> **Maturity: Exploratory** — These agents represent analytical concepts that have not been validated in production deployments. They are included as part of the fleet catalog to illustrate the range of agent-addressable analysis, not as proven operational patterns. Treat them as starting points for experimentation, not as deployment-ready specifications.
+
 These agents reason about dimensions that no individual human naturally perceives — full failure topologies, deep combinatorial state spaces, multi-year decay curves, emergent system behaviors, security attack surfaces, and schema evolution trajectories. Their value is in surfacing the structural realities that become visible only when the observer can hold the entire system in view simultaneously.
 
 These are not continuous fleet members. They are deployed for specific review cycles, capacity planning sessions, pre-launch audits, or when a fleet needs to understand a dimension of its system that is invisible at normal human working scale.

--- a/aiStrat/monitor/README.md
+++ b/aiStrat/monitor/README.md
@@ -77,13 +77,13 @@ Every piece of external content destined for the Brain passes through a five-lay
 
 **Why this layer ordering matters:** Layers 1-3 are deterministic and LLM-free because they must be trustworthy against adversarial content specifically crafted to manipulate LLMs. If the primary defense relied on an LLM, an attacker could craft content that simultaneously attacks the fleet *and* disarms the defense. Layer 4 (LLM advisory) is additive only — it can reject but never approve — so even a compromised Layer 4 can only fail in one direction. **Principle: fail-open for discovery (the Monitor finds everything), fail-closed for ingestion (nothing enters the Brain without passing all layers).**
 
-| Layer | Defense | What It Catches | LLM Involvement |
-|-------|---------|-----------------|-----------------|
-| **1. Structural** | Enforces schema, field lengths, valid categories, required fields | Malformed entries, oversized payloads, invalid categories | None — deterministic |
-| **2. Injection** | Encoding normalization + 70+ regex patterns scanning for prompt injection, XSS, SQL injection, command injection, secrets, PII | Adversarial content, credential exposure, data leaks | None — pattern matching |
-| **3. Deterministic Semantic** | Rule-based NLP, TF-IDF scoring against attack corpus, Bayesian text classification, authority-pattern detection | Authority spoofing, false credentials, behavior manipulation, dangerous advice | **None — LLM-airgapped** |
-| **4. LLM Advisory** | LLM classifier with hardcoded prompt. **Can only REJECT, never APPROVE.** | Subtle semantic attacks evading deterministic detection | LLM — advisory, additive rejection only |
-| **5. Antibody** | Converts detected attacks into Brain FAILURE entries for future defense | Rate-limited (50/hour), fingerprint-deduplicated, preserves attack patterns in defanged form | None — deterministic |
+| Layer | Defense | What It Catches | LLM Involvement | Implementation Status |
+|-------|---------|-----------------|-----------------|---------------------|
+| **1. Structural** | Enforces schema, field lengths, valid categories, required fields | Malformed entries, oversized payloads, invalid categories | None — deterministic | **Specified + partial implementation** (via scanner.sh validation) |
+| **2. Injection** | Encoding normalization + 70+ regex patterns scanning for prompt injection, XSS, SQL injection, command injection, secrets, PII | Adversarial content, credential exposure, data leaks | None — pattern matching | **Specified + partial implementation** (regex patterns defined) |
+| **3. Deterministic Semantic** | Rule-based NLP, TF-IDF scoring against attack corpus, Bayesian text classification, authority-pattern detection | Authority spoofing, false credentials, behavior manipulation, dangerous advice | **None — LLM-airgapped** | **Specified only** — no implementation exists |
+| **4. LLM Advisory** | LLM classifier with hardcoded prompt. **Can only REJECT, never APPROVE.** | Subtle semantic attacks evading deterministic detection | LLM — advisory, additive rejection only | **Specified only** — no implementation exists |
+| **5. Antibody** | Converts detected attacks into Brain FAILURE entries for future defense | Rate-limited (50/hour), fingerprint-deduplicated, preserves attack patterns in defanged form | None — deterministic | **Specified only** — no implementation exists |
 
 **Attack response flow:**
 1. Entry is **rejected** (never reaches the Brain)

--- a/aiStrat/sales-pitch-30min-guide.md
+++ b/aiStrat/sales-pitch-30min-guide.md
@@ -88,7 +88,7 @@
 **5. Institutional Memory (Brain Architecture)**
 - Persistent memory across sessions — lessons learned, project context, decision history
 - The fleet accumulates knowledge over time instead of cold-starting every session
-- Five-level memory architecture (Postgres+pgvector)
+- Three-level memory architecture: B1 (file-based) → B2 (SQLite + embeddings) → B3 (Postgres + pgvector)
 - Shared context enables coordination without redundant discovery
 
 ### Why This Matters (The Business Case)
@@ -128,10 +128,10 @@ The space is crowding from two directions — agent frameworks adding governance
 
 ### Development Status — Be Honest and Specific
 
-> "I'm at v0.5.3-alpha. Here's what that means in plain English:"
+> "I'm at v0.8.1-alpha. Here's what that means in plain English:"
 
 **What exists today:**
-- The complete specification — 15,000+ lines across 70+ files. The full architectural blueprint.
+- The complete specification — 114 files across 22 groups. The full architectural blueprint.
 - 12-part operational doctrine covering strategy, enforcement, execution, security, and quality assurance
 - 71 agent definitions with routing rules and interface contracts
 - The persistent memory (Brain) architecture — three-level semantic memory (B1: file-based → B2: SQLite → B3: Postgres+pgvector)
@@ -173,7 +173,7 @@ The space is crowding from two directions — agent frameworks adding governance
 → Multiple paths: hosted control plane (SaaS), enterprise runtime (on-prem), consulting/implementation, certification/training, marketplace for agent definitions. The spec is the foundation — monetization layers sit above it. *(Be honest if you haven't finalized this — it shows you're thinking about it seriously.)*
 
 **"What's your competitive moat?"**
-→ First-mover on the visibility and control layer specifically — not building agents, not compliance checkboxes, but the operational layer humans need to run agents safely. Model-agnostic and platform-agnostic (not locked to one vendor). The depth — 15,000+ lines of doctrine — is hard to replicate. The enforcement spectrum insight (hooks vs. instructions) is non-obvious and validated. And the 71 pre-defined roles with interface contracts don't exist anywhere else.
+→ First-mover on the visibility and control layer specifically — not building agents, not compliance checkboxes, but the operational layer humans need to run agents safely. Model-agnostic and platform-agnostic (not locked to one vendor). The depth — 114 files of doctrine across 22 groups — is hard to replicate. The enforcement spectrum insight (hooks vs. instructions) is non-obvious and validated. And the 71 pre-defined roles with interface contracts don't exist anywhere else.
 
 **"Is this a real market?"**
 → $660B+ being spent on AI infrastructure in 2026. Every dollar creates downstream demand for operations and governance. The $2 trillion repricing proves the market believes agents are replacing seats. The Gartner stat — 40% of deployments canceled by 2027 due to poor controls — proves governance is the bottleneck. The AI governance market alone is projected at $7.4B by 2030 (51% CAGR).


### PR DESCRIPTION
- Fix stale v0.5.3-alpha references in index.md, sales pitch, spec-gaps.md,
  and root AGENTS.md (source of truth is VERSION file: v0.8.1-alpha)
- Remove broken PLAN.md/PLAN2.md references from root AGENTS.md Ground Truth
- Add Framework Lenses reconciliation table to index.md mapping three pillars,
  five pillars, and seven components as complementary views
- Fix "five-level memory" claim in sales pitch to "three-level" (B1/B2/B3)
- Update file counts in sales pitch (70+ files → 114 files)
- Replace fragile cross-boundary relative links with explicit external references
- Add dataset record schemas (Decision Registry, Outcome Ledger) and worked
  example of Agent Calibration Loop to Part 12
- Add "Maturity: Exploratory" labels to scale and extended scale agents
- Add implementation status column to monitor README immune system table
- Add hypothetical target disclaimer and Basis/Validated columns to benchmarks
- Create spec-debt.md tracking 5 known areas of aspirational-vs-validated gap

https://claude.ai/code/session_01EY62W1BVAJKB5oCaZg5anM