### PR TITLE
Add Equal Brain Access principle across brain specs

### DIFF
--- a/aiStrat/admiral/spec/part10-admiral.md
+++ b/aiStrat/admiral/spec/part10-admiral.md
@@ -82,6 +82,49 @@ The Admiral performs coarse-grained task decomposition — breaking the current 
 
 -----
 
+## Admiral Brain Access
+
+> **TL;DR** — The Admiral must have direct, independent access to the Brain — not mediated through fleet agents. The Brain is a shared knowledge system serving two kinds of intelligence, and the Admiral's slower but more judgment-rich interaction style requires purpose-built interfaces.
+
+The fleet accesses the Brain through MCP tools at machine speed, querying hundreds of entries per session. The Admiral accesses the Brain through human-optimized interfaces — but the underlying access must be equally powerful. See Part 5, Knowledge Protocol, Equal Brain Access for the full specification.
+
+### Why This Matters for the Admiral
+
+The Admiral's primary value is **institutional insight and judgment** — understanding *why* a decision was made, whether a pattern is accidental or intentional, and how organizational context affects technical choices. These are exactly the questions the Brain can answer, but only if the Admiral can ask them directly.
+
+Without direct Brain access, the Admiral is dependent on fleet agents to retrieve and summarize institutional knowledge. This creates two failure modes:
+
+1. **Lossy mediation** — the agent retrieves Brain entries but summarizes away the nuance the Admiral needs for judgment. The Admiral makes decisions on incomplete institutional context.
+2. **Latency bottleneck** — the Admiral must wait for an agent to be available, formulate a query, return results, and explain them. For time-sensitive escalations, this delay degrades decision quality.
+
+### Admiral Query Patterns
+
+The Admiral's Brain queries differ from fleet agent queries in important ways:
+
+| Pattern | Fleet Agent | Admiral |
+|---|---|---|
+| **Frequency** | High (dozens per session) | Lower (targeted, judgment-driven) |
+| **Breadth** | Usually project-scoped | Often cross-project, looking for institutional patterns |
+| **Depth** | Retrieve and apply | Retrieve, evaluate, contextualize, and decide |
+| **Follow-up** | Rare (apply first result) | Common (explore chains, contradictions, history) |
+| **Time horizon** | Current session needs | Long-term trends, recurring failures, strategic patterns |
+
+These patterns require interfaces that support exploration and follow-up, not just single-shot retrieval. The Control Plane dashboard (CP2+), CLI tools, and natural language Brain queries via an LLM intermediary all serve this need.
+
+### Recording Admiral Knowledge
+
+The Admiral is often the sole source of institutional knowledge that no agent possesses — organizational context, stakeholder intent, strategic rationale, historical decisions made before the fleet existed. The Brain's recording interfaces must be equally accessible to the Admiral:
+
+- **CLI:** `brain_record` shell wrappers for terminal workflows
+- **Dashboard:** Entry creation forms in the Control Plane (CP2+)
+- **Inline:** During escalation review, the Admiral records decisions and rationale directly into the Brain as part of the resolution workflow
+
+The Admiral's contributions carry `authority_tier: admiral` provenance, giving them the highest trust weight in the retrieval pipeline's provenance signal.
+
+> **ANTI-PATTERN: ADMIRAL AS PASSIVE CONSUMER** — The Admiral reads Brain entries but never writes them. Institutional knowledge stays in the Admiral's head, inaccessible to the fleet. When the Admiral is unavailable, the fleet operates without strategic context. The Admiral must actively contribute knowledge, not just consume it.
+
+-----
+
 ## Human-Expert Routing
 
 > **TL;DR** — The Admiral is not omniscient. Route regulatory, design, business strategy, domain performance, and security risk decisions to subject-matter experts. Package the question. Track the response. Integrate it as Ground Truth.

--- a/aiStrat/admiral/spec/part5-brain.md
+++ b/aiStrat/admiral/spec/part5-brain.md
@@ -292,18 +292,43 @@ Example: `brain_query("authentication approach for stateless API", project="task
 
 > **Why mandatory for Propose/Escalate but not Autonomous?** Autonomous decisions are high-frequency, low-risk, and within established patterns — adding a Brain query to every one would create latency without proportional value. Propose and Escalate decisions are low-frequency, high-impact, and often novel — exactly the cases where institutional memory prevents the most expensive mistakes.
 
+### Equal Brain Access
+
+The Brain serves two fundamentally different kinds of intelligence: **fleet agents** (LLMs) and the **Admiral** (human). Both must have equal opportunity to query and communicate with the Brain. This is a permissions requirement as much as it is an accessibility requirement.
+
+**Why equal access matters:**
+
+- **LLMs** are highly skilled at retrieval across large knowledge sets — they can synthesize patterns, surface non-obvious connections, and query at machine speed across every entry the Brain holds.
+- **Humans** are often more institutionally insightful and capable of judgment — they bring strategic context, organizational knowledge, and ethical reasoning that no model possesses — but they are much slower.
+- **Optimal communication** requires empowering both. A Brain that is easy for agents to query but opaque to humans creates an information asymmetry that undermines the Admiral's judgment. A Brain that requires human expertise to navigate but lacks programmatic interfaces cripples the fleet's institutional memory.
+
+**Equal access does not mean identical interfaces.** Fleet agents access the Brain through MCP tools (`brain_query`, `brain_record`, etc.) optimized for programmatic, high-frequency interaction. The Admiral accesses the Brain through human-optimized interfaces — dashboards, CLI tools, natural language queries mediated by an LLM, or direct database access. The principle is that **every operation available to fleet agents must have a human-accessible equivalent**, and the Admiral's ability to query, explore, and understand the Brain must never lag behind the fleet's.
+
+| Interface | Serves | Optimized For |
+|---|---|---|
+| **MCP tools** (`brain_query`, etc.) | Fleet agents | Programmatic access, high frequency, structured I/O |
+| **CLI tools** (`brain_record`, `brain_query` shell wrappers) | Admiral (human) | Terminal workflows, scripted queries, quick lookups |
+| **Dashboard** (Control Plane CP2+) | Admiral (human) | Visual exploration, trend analysis, knowledge health |
+| **Natural language query** (via LLM intermediary) | Admiral (human) | Semantic exploration, "what do we know about X?" |
+| **Direct database access** (B2+) | Admiral (human) | Ad hoc analysis, bulk operations, custom reports |
+
+**The principle:** The Admiral must never need to ask an agent "what does the Brain say about X?" as the only path to Brain knowledge. The Admiral queries the Brain directly — through whichever interface suits the moment — and brings human judgment to what the Brain returns. Equally, agents must never be blocked from Brain access while waiting for human mediation. Both parties query independently, contribute independently, and the Brain serves both without preference.
+
+> **ANTI-PATTERN: FLEET-ONLY BRAIN** — The Brain's interfaces are optimized exclusively for MCP tool access. The Admiral can only see Brain contents by asking an agent to query on their behalf, or by reading raw JSON files. The Admiral's slower pace of interaction means they fall behind on institutional knowledge. Decisions that should be informed by Brain precedent are made without it — not because the knowledge doesn't exist, but because the human couldn't access it in time. Equal access prevents this asymmetry.
+
 ### Access Control
 
-Not every agent should read or write everything. **Access control is mandatory and enforced — not advisory.**
+Not every agent should read or write everything. **Access control is mandatory and enforced — not advisory.** Access control governs *authority* (who may perform which operations), not *accessibility* (whether the interface exists). Both the Admiral and fleet agents must have accessible interfaces at every authority level they hold.
 
 | Permission | Who | Why |
 |---|---|---|
-| **Read own project** | All agents in the fleet | Agents need project-specific history |
+| **Read own project** | All agents in the fleet, Admiral | Agents need project-specific history; the Admiral needs visibility into any project |
 | **Read cross-project** | Orchestrators, Admiral | Cross-pollination requires trust |
-| **Write** | All agents (own project only) | Every agent contributes knowledge |
+| **Write** | All agents (own project only), Admiral | Every agent contributes knowledge; the Admiral contributes from any interface |
 | **Write cross-project** | Admiral only | Cross-project entries must be validated |
 | **Supersede** | Admiral, orchestrator | Correcting the record requires authority |
 | **Delete** | Admiral only (soft delete) | The Brain does not forget; it supersedes |
+| **Audit** | Admiral only | Full operational visibility requires human accountability |
 
 #### Zero-Trust Identity Verification
 

--- a/aiStrat/brain/README.md
+++ b/aiStrat/brain/README.md
@@ -162,10 +162,22 @@ brain/
 | Knowledge Protocol (Part 5) | MCP server tools, access control, audit logging, identity token lifecycle, RAG security |
 | Intelligence Lifecycle (Part 5) | Retrieval pipeline, multi-hop retrieval, knowledge graph, cross-project intelligence |
 
+## Equal Brain Access
+
+The Brain serves two fundamentally different kinds of intelligence: **fleet agents** (LLMs) and the **Admiral** (human). Both must have equal opportunity to query and communicate with the Brain.
+
+- **Fleet agents** access the Brain through MCP tools — programmatic, high-frequency, optimized for structured I/O.
+- **The Admiral** accesses the Brain through human-optimized interfaces — CLI tools, dashboards (CP2+), natural language queries via LLM intermediary, or direct database access.
+
+LLMs are highly skilled at retrieval across large knowledge sets. Humans are more institutionally insightful and capable of judgment but much slower. Enabling and empowering both is required for optimal communication. Every operation available to fleet agents must have a human-accessible equivalent.
+
+See [admiral/part5-brain.md](../admiral/spec/part5-brain.md) Knowledge Protocol, Equal Brain Access for the full specification, and [admiral/part10-admiral.md](../admiral/spec/part10-admiral.md) Admiral Brain Access for the Admiral's query patterns and recording workflows.
+
 ## Architecture Decisions
 
 - **Postgres + pgvector** chosen for combined structured/unstructured/vector storage in a single transactional system. No vendor lock-in.
-- **MCP as the universal interface.** Any agent that speaks MCP speaks to the Brain — Claude Code, Agent SDK agents, third-party agents. Protocol-agnostic by design.
+- **Equal access for humans and agents.** The Brain is not a fleet-only resource. Human-optimized interfaces (CLI, dashboard, natural language, direct SQL) provide the Admiral with equally powerful access to institutional knowledge. See Equal Brain Access above.
+- **MCP as the universal interface.** Any agent that speaks MCP speaks to the Brain — Claude Code, Agent SDK agents, third-party agents. Protocol-agnostic by design. Human access complements MCP through CLI wrappers and dashboard views that invoke the same underlying operations.
 - **Zero-trust access control.** Identity tokens are cryptographically signed, session-scoped, non-delegable. No caller-declared identity trusted.
 - **Embedding generation is pluggable.** The `EmbeddingProvider` interface accepts any implementation — OpenAI, local models, or future alternatives. The `embedding_model` column tracks which model produced each entry's embedding for migration purposes, but no MCP tool exposes embedding model selection or re-embedding. Embedding generation is an infrastructure concern managed at the MCP server configuration level, not an agent-facing operation. At B2 (SQLite), the embedding model is configured at deployment time. Agents interact with embeddings indirectly through `brain_query` (semantic search) and `brain_record` (automatic embedding on write).
 - **Retrieval is multi-signal.** Vector similarity alone is insufficient. The pipeline applies eight ranking signals from Part 5, Intelligence Lifecycle, including multi-hop traversal and contradiction awareness.


### PR DESCRIPTION
The Brain serves two fundamentally different kinds of intelligence — fleet
agents (LLMs) and the Admiral (human). Both must have equal opportunity to
query and communicate with the Brain. LLMs excel at large-scale retrieval;
humans bring institutional insight and judgment but operate slower. Enabling
both optimally requires accessible interfaces for each.

Changes:
- part5-brain.md: New "Equal Brain Access" section establishing the principle,
  interface matrix (MCP/CLI/dashboard/NL query/direct DB), anti-pattern
  (FLEET-ONLY BRAIN), and updated Access Control table with clarified
  authority-vs-accessibility distinction
- part10-admiral.md: New "Admiral Brain Access" section covering human query
  patterns, failure modes of mediated access, and recording workflows with
  anti-pattern (ADMIRAL AS PASSIVE CONSUMER)
- brain/README.md: New "Equal Brain Access" overview section and updated
  Architecture Decisions with dual-access principle

https://claude.ai/code/session_012buDd6kjPEZpMQF9xozMoQ