### PR TITLE
feat(strategy): Ground Truth template and tooling (ST-01)

### DIFF
--- a/admiral/bin/generate_ground_truth
+++ b/admiral/bin/generate_ground_truth
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Admiral Framework — Ground Truth Document Generator
+# Scaffolds a blank ground-truth.json from the template.
+# Usage: generate_ground_truth <target-directory>
+# Exit codes: 0=created, 1=already exists or soft error, 2=hard error
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADMIRAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$ADMIRAL_DIR/templates/ground-truth.template.json"
+OUTPUT_FILENAME="ground-truth.json"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: generate_ground_truth <target-directory>"
+  echo ""
+  echo "Scaffolds a blank Ground Truth document (ground-truth.json) in the"
+  echo "specified directory from the Admiral Framework template."
+  echo ""
+  echo "Options:"
+  echo "  target-directory  Path where ground-truth.json will be created."
+  echo ""
+  echo "The generated file follows the ground-truth.v1.schema.json schema."
+  echo "Fill in all empty fields, then validate with validate_ground_truth."
+  exit 1
+fi
+
+TARGET_DIR="$1"
+OUTPUT_PATH="$TARGET_DIR/$OUTPUT_FILENAME"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "ERROR: Target directory does not exist: $TARGET_DIR"
+  exit 2
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "ERROR: Template not found at: $TEMPLATE"
+  exit 2
+fi
+
+if [ -f "$OUTPUT_PATH" ]; then
+  echo "ERROR: $OUTPUT_FILENAME already exists at $OUTPUT_PATH"
+  echo "Remove it first or choose a different directory."
+  exit 1
+fi
+
+# Copy the template and set today's date
+TODAY="$(date +%Y-%m-%d)"
+jq --arg date "$TODAY" '.project.last_updated = $date' "$TEMPLATE" > "$OUTPUT_PATH"
+
+echo "Created $OUTPUT_PATH"
+echo "Next steps:"
+echo "  1. Fill in all empty fields in the document"
+echo "  2. Run: validate_ground_truth $OUTPUT_PATH"

--- a/admiral/bin/validate_ground_truth
+++ b/admiral/bin/validate_ground_truth
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Admiral Framework — Ground Truth Document Validator
+# Validates a filled-in ground-truth.json against the schema.
+# Checks: required fields, empty strings, vague versions, enum values.
+# Usage: validate_ground_truth <path-to-ground-truth.json>
+# Exit codes: 0=valid, 1=warnings only, 2=hard failures
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADMIRAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCHEMA="$ADMIRAL_DIR/schemas/ground-truth.v1.schema.json"
+
+ERRORS=()
+WARNINGS=()
+
+if [ $# -lt 1 ]; then
+  echo "Usage: validate_ground_truth <path-to-ground-truth.json>"
+  echo ""
+  echo "Validates a Ground Truth document against the Admiral Framework schema."
+  echo "Checks required fields, empty values, vague versions, and enum constraints."
+  echo ""
+  echo "Exit codes:"
+  echo "  0  Document is valid"
+  echo "  1  Warnings (document usable but incomplete)"
+  echo "  2  Errors (document invalid, must fix before use)"
+  exit 1
+fi
+
+DOC="$1"
+
+if [ ! -f "$DOC" ]; then
+  echo "ERROR: File not found: $DOC"
+  exit 2
+fi
+
+if ! jq empty "$DOC" 2>/dev/null; then
+  echo "ERROR: Not valid JSON: $DOC"
+  exit 2
+fi
+
+# --- Helper functions ---
+
+check_required_key() {
+  local path="$1"
+  local label="$2"
+  local val
+  val=$(jq -r "$path // empty" "$DOC" 2>/dev/null)
+  if [ -z "$val" ]; then
+    ERRORS+=("Missing required field: $label ($path)")
+  fi
+}
+
+check_nonempty_string() {
+  local path="$1"
+  local label="$2"
+  local val
+  val=$(jq -r "$path // empty" "$DOC" 2>/dev/null)
+  if [ -z "$val" ]; then
+    ERRORS+=("Empty required string: $label ($path)")
+  fi
+}
+
+check_enum() {
+  local path="$1"
+  local label="$2"
+  shift 2
+  local allowed=("$@")
+  local val
+  val=$(jq -r "$path // empty" "$DOC" 2>/dev/null)
+  if [ -z "$val" ]; then
+    ERRORS+=("Missing required enum: $label ($path)")
+    return
+  fi
+  local found=false
+  for a in "${allowed[@]}"; do
+    if [ "$val" = "$a" ]; then
+      found=true
+      break
+    fi
+  done
+  if [ "$found" = false ]; then
+    ERRORS+=("Invalid value for $label ($path): '$val' — allowed: ${allowed[*]}")
+  fi
+}
+
+check_nonempty_array() {
+  local path="$1"
+  local label="$2"
+  local count
+  count=$(jq "$path | length" "$DOC" 2>/dev/null || echo "0")
+  if [ "$count" -eq 0 ]; then
+    ERRORS+=("Empty required array: $label ($path)")
+  fi
+}
+
+# Vague version detector per spec: reject latest, stable, current, newest, recent, lts
+VAGUE_PATTERN='(^|\s)(latest|stable|current|newest|recent|lts)(\s|$)'
+
+check_versions() {
+  local path="$1"
+  local label="$2"
+  local count
+  count=$(jq "$path | length" "$DOC" 2>/dev/null || echo "0")
+  for ((i=0; i<count; i++)); do
+    local item
+    item=$(jq -r "${path}[$i]" "$DOC" 2>/dev/null)
+    if echo "$item" | grep -iEq "$VAGUE_PATTERN"; then
+      ERRORS+=("Vague version in $label: '$item' — use exact version numbers (reject latest/stable/current/newest/recent/lts)")
+    fi
+  done
+}
+
+# --- Validate top-level required keys ---
+
+for key in schema_version project mission boundaries success_criteria ground_truth; do
+  val=$(jq -r ".$key // empty" "$DOC" 2>/dev/null)
+  if [ -z "$val" ] && [ "$(jq "has(\"$key\")" "$DOC" 2>/dev/null)" != "true" ]; then
+    ERRORS+=("Missing required top-level key: $key")
+  fi
+done
+
+# --- Project ---
+
+check_nonempty_string ".project.name" "project.name"
+check_nonempty_string ".project.last_updated" "project.last_updated"
+check_enum ".project.phase" "project.phase" "greenfield" "feature-add" "refactor" "migration" "maintenance"
+
+# --- Mission ---
+
+check_nonempty_string ".mission.identity" "mission.identity"
+check_nonempty_string ".mission.success_state" "mission.success_state"
+check_nonempty_string ".mission.stakeholders" "mission.stakeholders"
+check_enum ".mission.phase" "mission.phase" "greenfield" "feature-add" "refactor" "migration" "maintenance"
+check_enum ".mission.pipeline_entry" "mission.pipeline_entry" "Requirements" "Design" "Tasks" "Implementation"
+
+# --- Boundaries ---
+
+check_nonempty_array ".boundaries.hard_constraints.tech_stack" "boundaries.hard_constraints.tech_stack"
+check_versions ".boundaries.hard_constraints.tech_stack" "boundaries.hard_constraints.tech_stack"
+
+check_nonempty_string ".boundaries.resource_budgets.token_budget" "boundaries.resource_budgets.token_budget"
+check_nonempty_string ".boundaries.resource_budgets.time_budget" "boundaries.resource_budgets.time_budget"
+check_nonempty_string ".boundaries.resource_budgets.tool_call_limits" "boundaries.resource_budgets.tool_call_limits"
+check_nonempty_array ".boundaries.resource_budgets.scope_boundary" "boundaries.resource_budgets.scope_boundary"
+check_nonempty_string ".boundaries.resource_budgets.quality_floor" "boundaries.resource_budgets.quality_floor"
+
+check_nonempty_array ".boundaries.llm_last.deterministic" "boundaries.llm_last.deterministic"
+check_nonempty_array ".boundaries.llm_last.llm_judgment" "boundaries.llm_last.llm_judgment"
+
+# --- Success Criteria ---
+
+check_nonempty_array ".success_criteria.functional" "success_criteria.functional"
+check_nonempty_array ".success_criteria.quality" "success_criteria.quality"
+check_nonempty_array ".success_criteria.completeness" "success_criteria.completeness"
+check_nonempty_array ".success_criteria.negative" "success_criteria.negative"
+check_enum ".success_criteria.failure_handling" "success_criteria.failure_handling" "escalate" "deliver_partial_with_explanation" "block_and_report"
+
+# --- Ground Truth ---
+
+check_nonempty_string ".ground_truth.domain_ontology.naming_conventions" "ground_truth.domain_ontology.naming_conventions"
+check_nonempty_array ".ground_truth.environment.tech_stack" "ground_truth.environment.tech_stack"
+check_versions ".ground_truth.environment.tech_stack" "ground_truth.environment.tech_stack"
+check_nonempty_string ".ground_truth.environment.infrastructure" "ground_truth.environment.infrastructure"
+check_nonempty_string ".ground_truth.configuration.agents_md" "ground_truth.configuration.agents_md"
+
+# --- Phase consistency check ---
+
+proj_phase=$(jq -r ".project.phase // empty" "$DOC" 2>/dev/null)
+mission_phase=$(jq -r ".mission.phase // empty" "$DOC" 2>/dev/null)
+if [ -n "$proj_phase" ] && [ -n "$mission_phase" ] && [ "$proj_phase" != "$mission_phase" ]; then
+  WARNINGS+=("Phase mismatch: project.phase='$proj_phase' vs mission.phase='$mission_phase'")
+fi
+
+# --- Output results ---
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo "VALIDATION FAILED — ${#ERRORS[@]} error(s):"
+  for err in "${ERRORS[@]}"; do
+    echo "  ERROR: $err"
+  done
+  if [ ${#WARNINGS[@]} -gt 0 ]; then
+    echo ""
+    echo "Warnings (${#WARNINGS[@]}):"
+    for w in "${WARNINGS[@]}"; do
+      echo "  WARN: $w"
+    done
+  fi
+  exit 2
+fi
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo "VALIDATION PASSED with ${#WARNINGS[@]} warning(s):"
+  for w in "${WARNINGS[@]}"; do
+    echo "  WARN: $w"
+  done
+  exit 1
+fi
+
+echo "VALIDATION PASSED — Ground Truth document is valid."
+exit 0

--- a/admiral/schemas/ground-truth.v1.schema.json
+++ b/admiral/schemas/ground-truth.v1.schema.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ground-truth.v1.schema.json",
+  "title": "Admiral Framework Ground Truth Document",
+  "description": "Machine-readable Ground Truth template defining Mission, Boundaries, Success Criteria, and environmental context per Admiral Spec Part 1 (Strategy) and Part 2 (Context).",
+  "type": "object",
+  "required": ["schema_version", "project", "mission", "boundaries", "success_criteria", "ground_truth"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semantic version of this schema."
+    },
+    "project": {
+      "type": "object",
+      "required": ["name", "last_updated", "phase"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Project name."
+        },
+        "last_updated": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "ISO 8601 date of last update."
+        },
+        "phase": {
+          "type": "string",
+          "enum": ["greenfield", "feature-add", "refactor", "migration", "maintenance"],
+          "description": "Current project phase."
+        }
+      }
+    },
+    "mission": {
+      "type": "object",
+      "required": ["identity", "success_state", "stakeholders", "phase", "pipeline_entry"],
+      "additionalProperties": false,
+      "description": "Strategy Triangle vertex 1: what are we building and what does success look like.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "minLength": 1,
+          "description": "One-sentence project identity: 'This project is [identity].'"
+        },
+        "success_state": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Concrete, observable success state: 'It is successful when [state].'"
+        },
+        "stakeholders": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Who this is for and their core need: 'Built for [who] who need [what].'"
+        },
+        "phase": {
+          "type": "string",
+          "enum": ["greenfield", "feature-add", "refactor", "migration", "maintenance"],
+          "description": "Current phase (must match project.phase)."
+        },
+        "pipeline_entry": {
+          "type": "string",
+          "enum": ["Requirements", "Design", "Tasks", "Implementation"],
+          "description": "Where the fleet takes over in the pipeline."
+        }
+      }
+    },
+    "boundaries": {
+      "type": "object",
+      "required": ["non_goals", "hard_constraints", "resource_budgets", "llm_last"],
+      "additionalProperties": false,
+      "description": "Strategy Triangle vertex 2: what the project is NOT, resource limits, deterministic-vs-LLM line.",
+      "properties": {
+        "non_goals": {
+          "type": "object",
+          "required": ["functional", "quality", "architectural"],
+          "additionalProperties": false,
+          "properties": {
+            "functional": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Features or capabilities explicitly out of scope."
+            },
+            "quality": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Levels of polish not required at this phase."
+            },
+            "architectural": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Patterns or technologies that must NOT be used."
+            }
+          }
+        },
+        "hard_constraints": {
+          "type": "object",
+          "required": ["tech_stack", "external_deadlines", "compatibility", "regulatory", "protocol_scope"],
+          "additionalProperties": false,
+          "properties": {
+            "tech_stack": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1,
+              "description": "Exact languages/frameworks/tools WITH version numbers. Reject vague versions (latest, stable, current, newest, recent, lts)."
+            },
+            "external_deadlines": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Ship dates, demo dates, review dates."
+            },
+            "compatibility": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Browser support, API backward compat, platform requirements."
+            },
+            "regulatory": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Legal or organizational mandates."
+            },
+            "protocol_scope": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Approved MCP servers, A2A requirements, trust classification policy."
+            }
+          }
+        },
+        "resource_budgets": {
+          "type": "object",
+          "required": ["token_budget", "time_budget", "tool_call_limits", "scope_boundary", "quality_floor"],
+          "additionalProperties": false,
+          "properties": {
+            "token_budget": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Max tokens per task before deliver or escalate."
+            },
+            "time_budget": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Wall-clock time limit per task."
+            },
+            "tool_call_limits": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Max API/tool invocations per task."
+            },
+            "scope_boundary": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "description": "File paths, repos, services each agent may touch."
+            },
+            "quality_floor": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Minimum acceptable quality bar (concrete definition)."
+            }
+          }
+        },
+        "llm_last": {
+          "type": "object",
+          "required": ["deterministic", "llm_judgment"],
+          "additionalProperties": false,
+          "properties": {
+            "deterministic": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "description": "Tasks handled by static analysis, linters, shell commands, type checkers."
+            },
+            "llm_judgment": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "description": "Tasks requiring understanding of intent, tradeoffs, novel design."
+            }
+          }
+        }
+      }
+    },
+    "success_criteria": {
+      "type": "object",
+      "required": ["functional", "quality", "completeness", "negative", "failure_handling"],
+      "additionalProperties": false,
+      "description": "Strategy Triangle vertex 3: machine-verifiable definition of done.",
+      "properties": {
+        "functional": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "description": "What must the output DO? Testable behaviors."
+        },
+        "quality": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "description": "Measurable gates: linting, tests, coverage thresholds."
+        },
+        "completeness": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "description": "What must exist beyond core deliverable."
+        },
+        "negative": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "description": "What output must NOT do."
+        },
+        "failure_handling": {
+          "type": "string",
+          "enum": ["escalate", "deliver_partial_with_explanation", "block_and_report"],
+          "description": "What happens if criteria cannot be met."
+        },
+        "judgment_boundaries": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Where criteria are ambiguous — name explicitly with decision authority tier."
+        }
+      }
+    },
+    "ground_truth": {
+      "type": "object",
+      "required": ["domain_ontology", "environment", "configuration"],
+      "additionalProperties": false,
+      "description": "The single source of reality per Part 2 Section 2.",
+      "properties": {
+        "domain_ontology": {
+          "type": "object",
+          "required": ["glossary", "naming_conventions", "status_definitions", "architecture_vocabulary"],
+          "additionalProperties": false,
+          "properties": {
+            "glossary": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "Project-specific terms with precise definitions."
+            },
+            "naming_conventions": {
+              "type": "string",
+              "minLength": 1,
+              "description": "File, branch, variable, component naming conventions."
+            },
+            "status_definitions": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "What in_progress, blocked, done, etc. mean concretely."
+            },
+            "architecture_vocabulary": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "What service, layer, module, feature mean in this project."
+            }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "required": ["tech_stack", "infrastructure", "access_permissions", "known_issues", "external_dependencies"],
+          "additionalProperties": false,
+          "properties": {
+            "tech_stack": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1,
+              "description": "Exact versions. NEVER vague (latest, stable, current, newest, recent, lts)."
+            },
+            "infrastructure": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Where things run, how they connect, deployment targets."
+            },
+            "access_permissions": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "description": "Per-role enumeration of what APIs, services, files, tools each role has access to."
+            },
+            "known_issues": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Bugs, limitations, workarounds, do-not-touch areas."
+            },
+            "external_dependencies": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Third-party services, rate limits, SLAs, known instabilities."
+            }
+          }
+        },
+        "configuration": {
+          "type": "object",
+          "required": ["agents_md", "tool_pointers", "hooks_count", "hooks_last_audit", "skills", "mcp_servers"],
+          "additionalProperties": false,
+          "properties": {
+            "agents_md": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Location of canonical AGENTS.md."
+            },
+            "tool_pointers": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Tool-specific config files (CLAUDE.md, .cursorrules, etc.)."
+            },
+            "hooks_count": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of active hooks."
+            },
+            "hooks_last_audit": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "Date of last hooks audit."
+            },
+            "skills": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "On-demand knowledge skill files."
+            },
+            "mcp_servers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "version", "trust_classification"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Pinned version. NEVER 'latest'."
+                  },
+                  "trust_classification": {
+                    "type": "string",
+                    "enum": ["official", "community", "internal"],
+                    "description": "Per Part 13 Section 2 Server Addition Checklist."
+                  }
+                }
+              },
+              "description": "MCP servers with pinned versions and trust classification."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/admiral/templates/ground-truth.template.json
+++ b/admiral/templates/ground-truth.template.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.0.0",
+  "project": {
+    "name": "",
+    "last_updated": "",
+    "phase": ""
+  },
+  "mission": {
+    "identity": "",
+    "success_state": "",
+    "stakeholders": "",
+    "phase": "",
+    "pipeline_entry": ""
+  },
+  "boundaries": {
+    "non_goals": {
+      "functional": [],
+      "quality": [],
+      "architectural": []
+    },
+    "hard_constraints": {
+      "tech_stack": [],
+      "external_deadlines": [],
+      "compatibility": [],
+      "regulatory": [],
+      "protocol_scope": []
+    },
+    "resource_budgets": {
+      "token_budget": "",
+      "time_budget": "",
+      "tool_call_limits": "",
+      "scope_boundary": [],
+      "quality_floor": ""
+    },
+    "llm_last": {
+      "deterministic": [],
+      "llm_judgment": []
+    }
+  },
+  "success_criteria": {
+    "functional": [],
+    "quality": [],
+    "completeness": [],
+    "negative": [],
+    "failure_handling": "",
+    "judgment_boundaries": []
+  },
+  "ground_truth": {
+    "domain_ontology": {
+      "glossary": {},
+      "naming_conventions": "",
+      "status_definitions": {},
+      "architecture_vocabulary": {}
+    },
+    "environment": {
+      "tech_stack": [],
+      "infrastructure": "",
+      "access_permissions": {},
+      "known_issues": [],
+      "external_dependencies": []
+    },
+    "configuration": {
+      "agents_md": "",
+      "tool_pointers": [],
+      "hooks_count": 0,
+      "hooks_last_audit": "",
+      "skills": [],
+      "mcp_servers": []
+    }
+  }
+}

--- a/admiral/tests/test_ground_truth.sh
+++ b/admiral/tests/test_ground_truth.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+# Admiral Framework — Ground Truth Tooling Tests
+# Tests generate_ground_truth.sh and validate_ground_truth.sh
+# Exit code: 0 = all pass, 1 = failures
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADMIRAL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+GENERATE="$ADMIRAL_DIR/bin/generate_ground_truth"
+VALIDATE="$ADMIRAL_DIR/bin/validate_ground_truth"
+SCHEMA="$ADMIRAL_DIR/schemas/ground-truth.v1.schema.json"
+TEMPLATE="$ADMIRAL_DIR/templates/ground-truth.template.json"
+
+PASS=0
+FAIL=0
+ERRORS=""
+TMPDIR_BASE=""
+
+assert_exit_code() {
+  local test_name="$1"
+  local expected_code="$2"
+  local actual_code="$3"
+  if [ "$actual_code" -eq "$expected_code" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected exit $expected_code, got $actual_code\n"
+    echo "  [FAIL] $test_name (expected exit $expected_code, got $actual_code)"
+  fi
+}
+
+assert_contains() {
+  local test_name="$1"
+  local output="$2"
+  local expected="$3"
+  if echo "$output" | grep -q "$expected"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected '$expected' in output\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+assert_file_exists() {
+  local test_name="$1"
+  local filepath="$2"
+  if [ -f "$filepath" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — file '$filepath' does not exist\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+assert_valid_json() {
+  local test_name="$1"
+  local filepath="$2"
+  if jq empty "$filepath" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — '$filepath' is not valid JSON\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+setup() {
+  TMPDIR_BASE="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_BASE"
+}
+
+# ============================================================
+# Prerequisite checks
+# ============================================================
+echo "=== Prerequisite Checks ==="
+
+if [ ! -f "$SCHEMA" ]; then
+  echo "  [SKIP] Schema not found at $SCHEMA"
+  exit 1
+fi
+
+if [ ! -f "$GENERATE" ]; then
+  echo "  [SKIP] Generator not found at $GENERATE"
+  exit 1
+fi
+
+if [ ! -f "$VALIDATE" ]; then
+  echo "  [SKIP] Validator not found at $VALIDATE"
+  exit 1
+fi
+
+echo "  All prerequisites found."
+echo ""
+
+# ============================================================
+# Schema Tests
+# ============================================================
+echo "=== Schema Tests ==="
+
+assert_valid_json "Schema is valid JSON" "$SCHEMA"
+assert_valid_json "Template is valid JSON" "$TEMPLATE"
+
+# Schema must define required top-level properties
+schema_props=$(jq -r '.properties | keys[]' "$SCHEMA" 2>/dev/null || echo "")
+assert_contains "Schema has 'project' property" "$schema_props" "project"
+assert_contains "Schema has 'mission' property" "$schema_props" "mission"
+assert_contains "Schema has 'boundaries' property" "$schema_props" "boundaries"
+assert_contains "Schema has 'success_criteria' property" "$schema_props" "success_criteria"
+assert_contains "Schema has 'ground_truth' property" "$schema_props" "ground_truth"
+
+echo ""
+
+# ============================================================
+# Generator Tests
+# ============================================================
+echo "=== Generator Tests ==="
+
+setup
+
+# Test: generates ground-truth.json in target directory
+output=$("$GENERATE" "$TMPDIR_BASE" 2>&1) || true
+assert_file_exists "Generator creates ground-truth.json" "$TMPDIR_BASE/ground-truth.json"
+assert_valid_json "Generated file is valid JSON" "$TMPDIR_BASE/ground-truth.json"
+
+# Test: generated file has all required top-level keys
+gen_keys=$(jq -r 'keys[]' "$TMPDIR_BASE/ground-truth.json" 2>/dev/null || echo "")
+assert_contains "Generated file has 'project' key" "$gen_keys" "project"
+assert_contains "Generated file has 'mission' key" "$gen_keys" "mission"
+assert_contains "Generated file has 'boundaries' key" "$gen_keys" "boundaries"
+assert_contains "Generated file has 'success_criteria' key" "$gen_keys" "success_criteria"
+assert_contains "Generated file has 'ground_truth' key" "$gen_keys" "ground_truth"
+
+# Test: refuses to overwrite existing file
+output2=$("$GENERATE" "$TMPDIR_BASE" 2>&1) || true
+rc=$?
+# Generator should warn about existing file (exit 1 = soft fail)
+assert_contains "Generator warns about existing file" "$output2" "already exists"
+
+teardown
+
+# Test: fails with no arguments
+output3=$("$GENERATE" 2>&1) || true
+assert_contains "Generator requires target directory" "$output3" "Usage"
+
+echo ""
+
+# ============================================================
+# Validator Tests — Happy Path
+# ============================================================
+echo "=== Validator Tests — Happy Path ==="
+
+setup
+
+# Create a valid, fully-filled ground truth document
+cat > "$TMPDIR_BASE/valid-gt.json" << 'VALIDEOF'
+{
+  "schema_version": "1.0.0",
+  "project": {
+    "name": "Test Project",
+    "last_updated": "2026-03-20",
+    "phase": "greenfield"
+  },
+  "mission": {
+    "identity": "This project is a test harness for Ground Truth validation.",
+    "success_state": "User can run validate_ground_truth.sh and get a pass/fail result in under 2 seconds.",
+    "stakeholders": "Developers who need to validate project Ground Truth documents.",
+    "phase": "greenfield",
+    "pipeline_entry": "Implementation"
+  },
+  "boundaries": {
+    "non_goals": {
+      "functional": ["Does not provide a GUI"],
+      "quality": ["Does not require 100% code coverage at this phase"],
+      "architectural": ["Does not use a database"]
+    },
+    "hard_constraints": {
+      "tech_stack": ["Bash 5.x", "jq 1.6+"],
+      "external_deadlines": [],
+      "compatibility": ["POSIX-compatible shells"],
+      "regulatory": [],
+      "protocol_scope": []
+    },
+    "resource_budgets": {
+      "token_budget": "10000 tokens per task",
+      "time_budget": "30 minutes per task",
+      "tool_call_limits": "50 tool calls per task",
+      "scope_boundary": ["admiral/"],
+      "quality_floor": "All tests pass, no lint errors"
+    },
+    "llm_last": {
+      "deterministic": ["Linting", "JSON schema validation", "Test execution"],
+      "llm_judgment": ["Architecture decisions", "Code review"]
+    }
+  },
+  "success_criteria": {
+    "functional": ["validate_ground_truth.sh exits 0 for valid documents"],
+    "quality": ["jq parses all JSON without errors"],
+    "completeness": ["All required fields documented"],
+    "negative": ["No files modified outside admiral/"],
+    "failure_handling": "escalate",
+    "judgment_boundaries": []
+  },
+  "ground_truth": {
+    "domain_ontology": {
+      "glossary": {"Ground Truth": "Single source of project reality"},
+      "naming_conventions": "snake_case for scripts, kebab-case for JSON files",
+      "status_definitions": {"done": "All tests pass and PR merged", "blocked": "Waiting on external dependency"},
+      "architecture_vocabulary": {"module": "A directory under admiral/ with a specific responsibility"}
+    },
+    "environment": {
+      "tech_stack": ["Bash 5.2", "jq 1.7", "Node.js 24.13.0"],
+      "infrastructure": "Local development, GitHub Actions CI",
+      "access_permissions": {"developer": ["read/write admiral/", "read aiStrat/"]},
+      "known_issues": [],
+      "external_dependencies": []
+    },
+    "configuration": {
+      "agents_md": "AGENTS.md at repo root",
+      "tool_pointers": ["CLAUDE.md"],
+      "hooks_count": 8,
+      "hooks_last_audit": "2026-03-20",
+      "skills": [],
+      "mcp_servers": []
+    }
+  }
+}
+VALIDEOF
+
+rc=0
+output=$("$VALIDATE" "$TMPDIR_BASE/valid-gt.json" 2>&1) || rc=$?
+assert_exit_code "Valid document passes validation" 0 "$rc"
+
+teardown
+echo ""
+
+# ============================================================
+# Validator Tests — Missing Required Fields
+# ============================================================
+echo "=== Validator Tests — Missing Required Fields ==="
+
+setup
+
+# Missing mission entirely
+cat > "$TMPDIR_BASE/no-mission.json" << 'EOF'
+{
+  "schema_version": "1.0.0",
+  "project": {"name": "Test", "last_updated": "2026-03-20", "phase": "greenfield"},
+  "boundaries": {
+    "non_goals": {"functional": [], "quality": [], "architectural": []},
+    "hard_constraints": {"tech_stack": ["Bash 5.x"], "external_deadlines": [], "compatibility": [], "regulatory": [], "protocol_scope": []},
+    "resource_budgets": {"token_budget": "10000", "time_budget": "30m", "tool_call_limits": "50", "scope_boundary": ["."], "quality_floor": "Tests pass"},
+    "llm_last": {"deterministic": ["linting"], "llm_judgment": ["review"]}
+  },
+  "success_criteria": {"functional": ["works"], "quality": ["passes"], "completeness": ["done"], "negative": ["none"], "failure_handling": "escalate", "judgment_boundaries": []},
+  "ground_truth": {
+    "domain_ontology": {"glossary": {}, "naming_conventions": "snake_case", "status_definitions": {}, "architecture_vocabulary": {}},
+    "environment": {"tech_stack": ["Bash 5.x"], "infrastructure": "local", "access_permissions": {}, "known_issues": [], "external_dependencies": []},
+    "configuration": {"agents_md": "AGENTS.md", "tool_pointers": [], "hooks_count": 0, "hooks_last_audit": "2026-03-20", "skills": [], "mcp_servers": []}
+  }
+}
+EOF
+
+rc=0
+output=$("$VALIDATE" "$TMPDIR_BASE/no-mission.json" 2>&1) || rc=$?
+assert_exit_code "Missing 'mission' fails with exit 2" 2 "$rc"
+assert_contains "Reports missing mission" "$output" "mission"
+
+# Empty identity field
+cat > "$TMPDIR_BASE/empty-identity.json" << 'EOF'
+{
+  "schema_version": "1.0.0",
+  "project": {"name": "Test", "last_updated": "2026-03-20", "phase": "greenfield"},
+  "mission": {
+    "identity": "",
+    "success_state": "Works correctly.",
+    "stakeholders": "Developers",
+    "phase": "greenfield",
+    "pipeline_entry": "Implementation"
+  },
+  "boundaries": {
+    "non_goals": {"functional": [], "quality": [], "architectural": []},
+    "hard_constraints": {"tech_stack": ["Bash 5.x"], "external_deadlines": [], "compatibility": [], "regulatory": [], "protocol_scope": []},
+    "resource_budgets": {"token_budget": "10000", "time_budget": "30m", "tool_call_limits": "50", "scope_boundary": ["."], "quality_floor": "Tests pass"},
+    "llm_last": {"deterministic": ["linting"], "llm_judgment": ["review"]}
+  },
+  "success_criteria": {"functional": ["works"], "quality": ["passes"], "completeness": ["done"], "negative": ["none"], "failure_handling": "escalate", "judgment_boundaries": []},
+  "ground_truth": {
+    "domain_ontology": {"glossary": {}, "naming_conventions": "snake_case", "status_definitions": {}, "architecture_vocabulary": {}},
+    "environment": {"tech_stack": ["Bash 5.x"], "infrastructure": "local", "access_permissions": {}, "known_issues": [], "external_dependencies": []},
+    "configuration": {"agents_md": "AGENTS.md", "tool_pointers": [], "hooks_count": 0, "hooks_last_audit": "2026-03-20", "skills": [], "mcp_servers": []}
+  }
+}
+EOF
+
+rc=0
+output=$("$VALIDATE" "$TMPDIR_BASE/empty-identity.json" 2>&1) || rc=$?
+assert_exit_code "Empty 'identity' fails with exit 2" 2 "$rc"
+assert_contains "Reports empty identity" "$output" "identity"
+
+teardown
+echo ""
+
+# ============================================================
+# Validator Tests — Vague Versions
+# ============================================================
+echo "=== Validator Tests — Vague Versions ==="
+
+setup
+
+cat > "$TMPDIR_BASE/vague-version.json" << 'EOF'
+{
+  "schema_version": "1.0.0",
+  "project": {"name": "Test", "last_updated": "2026-03-20", "phase": "greenfield"},
+  "mission": {
+    "identity": "A test project.",
+    "success_state": "Works correctly.",
+    "stakeholders": "Developers",
+    "phase": "greenfield",
+    "pipeline_entry": "Implementation"
+  },
+  "boundaries": {
+    "non_goals": {"functional": [], "quality": [], "architectural": []},
+    "hard_constraints": {"tech_stack": ["Node.js latest", "React stable"], "external_deadlines": [], "compatibility": [], "regulatory": [], "protocol_scope": []},
+    "resource_budgets": {"token_budget": "10000", "time_budget": "30m", "tool_call_limits": "50", "scope_boundary": ["."], "quality_floor": "Tests pass"},
+    "llm_last": {"deterministic": ["linting"], "llm_judgment": ["review"]}
+  },
+  "success_criteria": {"functional": ["works"], "quality": ["passes"], "completeness": ["done"], "negative": ["none"], "failure_handling": "escalate", "judgment_boundaries": []},
+  "ground_truth": {
+    "domain_ontology": {"glossary": {}, "naming_conventions": "snake_case", "status_definitions": {}, "architecture_vocabulary": {}},
+    "environment": {"tech_stack": ["Node.js latest"], "infrastructure": "local", "access_permissions": {}, "known_issues": [], "external_dependencies": []},
+    "configuration": {"agents_md": "AGENTS.md", "tool_pointers": [], "hooks_count": 0, "hooks_last_audit": "2026-03-20", "skills": [], "mcp_servers": []}
+  }
+}
+EOF
+
+rc=0
+output=$("$VALIDATE" "$TMPDIR_BASE/vague-version.json" 2>&1) || rc=$?
+assert_exit_code "Vague version strings fail with exit 2" 2 "$rc"
+assert_contains "Reports vague version" "$output" "latest"
+
+teardown
+echo ""
+
+# ============================================================
+# Validator Tests — Invalid Enums
+# ============================================================
+echo "=== Validator Tests — Invalid Enums ==="
+
+setup
+
+cat > "$TMPDIR_BASE/bad-phase.json" << 'EOF'
+{
+  "schema_version": "1.0.0",
+  "project": {"name": "Test", "last_updated": "2026-03-20", "phase": "greenfield"},
+  "mission": {
+    "identity": "A test project.",
+    "success_state": "Works correctly.",
+    "stakeholders": "Developers",
+    "phase": "deploying",
+    "pipeline_entry": "Implementation"
+  },
+  "boundaries": {
+    "non_goals": {"functional": [], "quality": [], "architectural": []},
+    "hard_constraints": {"tech_stack": ["Bash 5.x"], "external_deadlines": [], "compatibility": [], "regulatory": [], "protocol_scope": []},
+    "resource_budgets": {"token_budget": "10000", "time_budget": "30m", "tool_call_limits": "50", "scope_boundary": ["."], "quality_floor": "Tests pass"},
+    "llm_last": {"deterministic": ["linting"], "llm_judgment": ["review"]}
+  },
+  "success_criteria": {"functional": ["works"], "quality": ["passes"], "completeness": ["done"], "negative": ["none"], "failure_handling": "escalate", "judgment_boundaries": []},
+  "ground_truth": {
+    "domain_ontology": {"glossary": {}, "naming_conventions": "snake_case", "status_definitions": {}, "architecture_vocabulary": {}},
+    "environment": {"tech_stack": ["Bash 5.x"], "infrastructure": "local", "access_permissions": {}, "known_issues": [], "external_dependencies": []},
+    "configuration": {"agents_md": "AGENTS.md", "tool_pointers": [], "hooks_count": 0, "hooks_last_audit": "2026-03-20", "skills": [], "mcp_servers": []}
+  }
+}
+EOF
+
+rc=0
+output=$("$VALIDATE" "$TMPDIR_BASE/bad-phase.json" 2>&1) || rc=$?
+assert_exit_code "Invalid phase enum fails with exit 2" 2 "$rc"
+assert_contains "Reports invalid phase" "$output" "phase"
+
+teardown
+echo ""
+
+# ============================================================
+# Validator Tests — No Arguments
+# ============================================================
+echo "=== Validator Tests — Usage ==="
+
+output=$("$VALIDATE" 2>&1) || true
+rc=$?
+assert_contains "Validator shows usage without arguments" "$output" "Usage"
+
+echo ""
+
+# ============================================================
+# Results
+# ============================================================
+echo "========================================="
+echo "Ground Truth Tests: $PASS passed, $FAIL failed"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  echo -e "$ERRORS"
+  exit 1
+fi

--- a/plan/todo/01-strategy-foundation.md
+++ b/plan/todo/01-strategy-foundation.md
@@ -8,7 +8,7 @@ The Strategy Triangle (Mission, Boundaries, Success Criteria) is the foundation 
 
 ## Ground Truth Tooling
 
-- [ ] **ST-01: Ground Truth document template and tooling** — Create machine-readable YAML templates for Mission, Boundaries, and Success Criteria with all spec-defined fields; define `ground-truth.schema.json`; build `generate_ground_truth.sh` CLI to scaffold blank documents; build a validator that confirms filled-in documents have no empty required fields.
+- [x] **ST-01: Ground Truth document template and tooling** — Create machine-readable YAML templates for Mission, Boundaries, and Success Criteria with all spec-defined fields; define `ground-truth.schema.json`; build `generate_ground_truth.sh` CLI to scaffold blank documents; build a validator that confirms filled-in documents have no empty required fields.
 - [ ] **ST-02: Project readiness assessment tool** — Build `readiness_assess.sh` that accepts a project root and Ground Truth path, checks Ground Truth completeness, CI config, test suite, linter config, and documented conventions, and outputs Ready/Partially Ready/Not Ready with a detailed breakdown and preparation path.
 - [ ] **ST-03: Go/No-Go deployment gate** — Build `go_no_go_gate.sh` that invokes the readiness assessment (ST-02), exits non-zero for Not Ready projects, restricts Partially Ready to Starter profile, and supports Admiral override with justification logged to `override_log.jsonl`.
 


### PR DESCRIPTION
## Summary

- Adds `ground-truth.v1.schema.json` — JSON Schema defining all spec-required Ground Truth fields (Mission, Boundaries, Success Criteria, Domain Ontology, Environment, Configuration) per Admiral Spec Part 1 & Part 2
- Adds `generate_ground_truth` CLI to scaffold blank `ground-truth.json` from template
- Adds `validate_ground_truth` CLI to validate filled documents (required fields, empty strings, vague version rejection, enum constraints, phase consistency)
- 26 passing tests covering happy path, missing fields, empty strings, vague versions, invalid enums, and CLI usage

## Test plan

- [x] All 26 tests pass in `admiral/tests/test_ground_truth.sh`
- [x] Generator creates valid JSON from template
- [x] Generator refuses to overwrite existing files
- [x] Validator accepts valid documents (exit 0)
- [x] Validator rejects missing required fields (exit 2)
- [x] Validator rejects empty required strings (exit 2)
- [x] Validator rejects vague versions like "latest", "stable" (exit 2)
- [x] Validator rejects invalid enum values (exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)