### PR TITLE
docs: defer ST-06, ST-07 to Phase 3 (Stream 7 dependency)

### DIFF
--- a/plan/todo/01-strategy-foundation.md
+++ b/plan/todo/01-strategy-foundation.md
@@ -19,8 +19,8 @@ The Strategy Triangle (Mission, Boundaries, Success Criteria) is the foundation 
 
 ## Validation & Enforcement
 
-- [ ] **ST-06: Strategy Triangle validation hook** — Create a SessionStart hook that loads and validates the Ground Truth document against the schema on every session start; block on missing Ground Truth, warn on incomplete fields, log results for audit, and complete in under 2 seconds.
-- [ ] **ST-07: LLM-Last boundary enforcement** — Add an LLM-Last check to the Ground Truth validator ensuring each project's Boundaries document includes an explicit LLM-Last section; provide a reference template with common deterministic-first and LLM-judgment patterns.
+- [ ] **ST-06: Strategy Triangle validation hook** — *Deferred to Phase 3 (Stream 7 hook infrastructure dependency).* See `plan/todo/05-hooks-standing-orders-infrastructure.md`.
+- [ ] **ST-07: LLM-Last boundary enforcement** — *Deferred to Phase 3 (depends on ST-06).* See `plan/todo/05-hooks-standing-orders-infrastructure.md`.
 - [x] **ST-08: Boundaries checklist** — Build `validate_boundaries.sh` that reads the Boundaries section and reports which categories (Non-Goals, Hard Constraints, Resource Budgets) are present, intentionally N/A, or missing; integrate into readiness assessment (ST-02) so missing categories prevent Ready status.
 
 ---

--- a/plan/todo/05-hooks-standing-orders-infrastructure.md
+++ b/plan/todo/05-hooks-standing-orders-infrastructure.md
@@ -11,6 +11,11 @@
 - [ ] **S-03** — `governance_heartbeat_monitor.sh`: Monitor governance agent (Sentinel, Arbiter) health via heartbeat signals; alert on missing heartbeat after threshold; log heartbeat history to state
 - [ ] **S-04** — `protocol_registry_guard.sh`: Two enforcement surfaces: (1) validate protocol changes against SO-16 approval rules, (2) hard-block calls to unregistered MCP servers via approved registry (`admiral/config/approved_mcp_servers.json`); closes OWASP MCP09 gap
 
+## Deferred from Phase 0 (Strategy Foundation)
+
+- [ ] **ST-06** — Strategy Triangle validation hook: Create a SessionStart hook that loads and validates the Ground Truth document against the schema on every session start; block on missing Ground Truth, warn on incomplete fields, log results for audit, and complete in under 2 seconds. *(Deferred from Phase 0 — depends on Stream 7 hook infrastructure.)*
+- [ ] **ST-07** — LLM-Last boundary enforcement: Add an LLM-Last check to the Ground Truth validator ensuring each project's Boundaries document includes an explicit LLM-Last section; provide a reference template with common deterministic-first and LLM-judgment patterns. *(Deferred from Phase 0 — depends on ST-06.)*
+
 ## Hook Contracts (Stream 7, Section 7.1)
 
 - [ ] **S-04b** — Hook input/output contract specification: Document formal JSON schemas for all hook inputs (`{ "event", "tool", "params", "agent_identity", "trace_id" }`), output contracts (exit codes, stdout context feedback, stderr logging), per-hook payload shapes, and 30s default timeout semantics
@@ -86,6 +91,8 @@
 
 | Item | Depends on | Reason |
 |------|-----------|--------|
+| ST-06 | S-01 or S-03 (any SessionStart hook) | Needs hook infrastructure to create a SessionStart validation hook |
+| ST-07 | ST-06 | LLM-Last check extends the Ground Truth validation hook |
 | S-03 | S-15 | Heartbeat monitor needs alerting pipeline for external delivery |
 | S-07 | S-06 | Task routing queries the agent registry |
 | S-08 | S-06 | Tool permissions reference agent definitions from registry |


### PR DESCRIPTION
## Deferral of ST-06 and ST-07

These two Strategy Foundation tasks have hard dependencies on Phase 3 (Stream 7 hook infrastructure) and cannot be completed in Phase 0.

### ST-06: Strategy Triangle validation hook
- **Depends on:** SessionStart hook infrastructure (Stream 7)
- **What it does:** Validates Ground Truth on every session start
- **Moved to:** Phase 3 TODO, before hook contracts section

### ST-07: LLM-Last boundary enforcement
- **Depends on:** ST-06
- **What it does:** Validates LLM-Last section in Boundaries
- **Moved to:** Phase 3 TODO, after ST-06

### Changes
- Phase 0 TODO: marked both as deferred with cross-references
- Phase 3 TODO: added 'Deferred from Phase 0' section with full task descriptions
- Phase 3 dependency table: added ST-06 and ST-07 entries