### PR TITLE
fix: resolve shellcheck warnings in test files

### DIFF
--- a/admiral/tests/test_constants_sync.sh
+++ b/admiral/tests/test_constants_sync.sh
@@ -142,6 +142,7 @@ echo "=== Spot-Check Key Constants ==="
 
 # Verify specific constants match between shell and JSON
 for const in TOOL_TOKENS_BASH LOOP_MAX_SAME_ERROR FLEET_MAX_AGENTS BRAIN_COSINE_MIN_SCORE; do
+  # shellcheck source=/dev/null
   source "$SHELL_REG"
   shell_val="${!const}"
   json_val=$(jq -r ".constants.$const" "$JSON_REG")

--- a/admiral/tests/test_migration.sh
+++ b/admiral/tests/test_migration.sh
@@ -11,7 +11,6 @@ UPGRADE_CHECK="$ADMIRAL_DIR/bin/upgrade_check"
 PASS=0
 FAIL=0
 ERRORS=""
-TMPDIR_BASE=""
 
 assert_exit_code() {
   local test_name="$1"

--- a/admiral/tests/test_reference_constants.sh
+++ b/admiral/tests/test_reference_constants.sh
@@ -54,6 +54,7 @@ echo ""
 echo "=== Registry Loads Without Errors ==="
 
 rc=0
+# shellcheck source=/dev/null
 source "$REGISTRY" 2>&1 || rc=$?
 assert_eq "Registry sources without error" "0" "$rc"
 echo ""

--- a/admiral/tests/test_spec_change_impact.sh
+++ b/admiral/tests/test_spec_change_impact.sh
@@ -56,9 +56,9 @@ echo "=== Prerequisite Checks ==="
 for f in "$VALIDATE" "$SCHEMA" "$TEMPLATE"; do
   if [ -f "$f" ]; then
     PASS=$((PASS + 1))
-    echo "  [PASS] $(basename $f) found"
+    echo "  [PASS] $(basename "$f") found"
   else
-    echo "  [SKIP] $(basename $f) not found"
+    echo "  [SKIP] $(basename "$f") not found"
     exit 1
   fi
 done


### PR DESCRIPTION
Fixes CI shellcheck failures:

- **SC1090** in `test_constants_sync.sh` and `test_reference_constants.sh`: Add `shellcheck source=/dev/null` directives for dynamic source paths
- **SC2034** in `test_migration.sh`: Remove unused `TMPDIR_BASE` variable
- **SC2086** in `test_spec_change_impact.sh`: Quote `$f` in `basename` calls

All 107 tests across the four files still pass.