### PR TITLE
fix: simplify review — bugs, dead code, shared test library

### DIFF
--- a/admiral/bin/migrate
+++ b/admiral/bin/migrate
@@ -151,8 +151,8 @@ for script in "${migration_scripts[@]}"; do
     # Mark as applied
     echo "$script_name" >> "$APPLIED_LOG"
     APPLIED+=("$script_name")
-    # Remove from pending
-    unset 'PENDING[${#PENDING[@]}-1]'
+    # Remove from pending — double quotes required for parameter expansion
+    unset "PENDING[${#PENDING[@]}-1]"
     [ "$JSON_MODE" != true ] && echo "  [APPLIED] $script_name"
   else
     FAILED+=("$script_name: exit $rc — $output")

--- a/admiral/bin/readiness_assess
+++ b/admiral/bin/readiness_assess
@@ -124,9 +124,6 @@ fi
 # ============================================================
 # Check 3: CI Configuration
 # ============================================================
-ci_status="fail"
-ci_detail=""
-
 ci_found=false
 for ci_path in \
   "$PROJECT_ROOT/.github/workflows" \
@@ -142,21 +139,15 @@ for ci_path in \
 done
 
 if [ "$ci_found" = true ]; then
-  ci_status="pass"
-  ci_detail="CI configuration found"
-  CHECKS_PASS+=("CI: $ci_detail")
+  CHECKS_PASS+=("CI: CI configuration found")
 else
-  ci_detail="No CI configuration detected"
-  CHECKS_WARN+=("CI: $ci_detail")
+  CHECKS_WARN+=("CI: No CI configuration detected")
   PREPARATION+=("Add CI configuration (e.g., .github/workflows/ci.yml)")
 fi
 
 # ============================================================
 # Check 4: Test Suite
 # ============================================================
-test_status="fail"
-test_detail=""
-
 test_found=false
 for test_path in \
   "$PROJECT_ROOT/tests" \
@@ -166,8 +157,7 @@ for test_path in \
   "$PROJECT_ROOT/admiral/tests"; do
   if [ -d "$test_path" ]; then
     # Check there's at least one file in the test directory
-    file_count=$(find "$test_path" -type f -name "test_*" -o -name "*_test.*" -o -name "*.test.*" -o -name "*.spec.*" 2>/dev/null | head -1 | wc -l)
-    if [ "$file_count" -gt 0 ]; then
+    if find "$test_path" -type f \( -name "test_*" -o -name "*_test.*" -o -name "*.test.*" -o -name "*.spec.*" \) -print -quit 2>/dev/null | grep -q .; then
       test_found=true
       break
     fi
@@ -175,21 +165,15 @@ for test_path in \
 done
 
 if [ "$test_found" = true ]; then
-  test_status="pass"
-  test_detail="Test suite found"
-  CHECKS_PASS+=("Test suite: $test_detail")
+  CHECKS_PASS+=("Test suite: Test suite found")
 else
-  test_detail="No test suite detected"
-  CHECKS_WARN+=("Test suite: $test_detail")
+  CHECKS_WARN+=("Test suite: No test suite detected")
   PREPARATION+=("Add a test directory with test files (e.g., tests/test_*.sh)")
 fi
 
 # ============================================================
 # Check 5: Linter Configuration
 # ============================================================
-lint_status="fail"
-lint_detail=""
-
 lint_found=false
 for lint_path in \
   "$PROJECT_ROOT/.shellcheckrc" \
@@ -213,12 +197,9 @@ for lint_path in \
 done
 
 if [ "$lint_found" = true ]; then
-  lint_status="pass"
-  lint_detail="Linter configuration found"
-  CHECKS_PASS+=("Linter: $lint_detail")
+  CHECKS_PASS+=("Linter: Linter configuration found")
 else
-  lint_detail="No linter configuration detected"
-  CHECKS_WARN+=("Linter: $lint_detail")
+  CHECKS_WARN+=("Linter: No linter configuration detected")
   PREPARATION+=("Add linter configuration (e.g., .shellcheckrc, .eslintrc)")
 fi
 

--- a/admiral/bin/spec_first_gate
+++ b/admiral/bin/spec_first_gate
@@ -87,15 +87,10 @@ if [ -z "$ENTRY_ORDER" ]; then
   exit 2
 fi
 
-# Check all artifacts for stages with order < entry_order
+# Check artifacts for the entry stage and all upstream stages
 PRESENT=()
 MISSING=()
 
-# Get upstream stages (order < entry_order)
-upstream_stages=$(jq -r --argjson order "$ENTRY_ORDER" \
-  '[.stages[] | select(.order < $order) | .name] | .[]' "$MANIFEST" 2>/dev/null)
-
-# Also include the entry stage itself — its artifacts must exist
 all_check_stages=$(jq -r --argjson order "$ENTRY_ORDER" \
   '[.stages[] | select(.order <= $order) | .name] | .[]' "$MANIFEST" 2>/dev/null)
 

--- a/admiral/lib/assert.sh
+++ b/admiral/lib/assert.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Admiral Framework — Shared Test Assertion Library
+# Source this file in test scripts to get standard assert functions.
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/../lib/assert.sh"
+#
+# Provides: assert_exit_code, assert_contains, assert_not_contains,
+#           assert_eq, assert_gt, assert_valid_json, assert_file_exists,
+#           setup (tmpdir), teardown (cleanup), print_results
+
+PASS=0
+FAIL=0
+ERRORS=""
+TMPDIR_BASE=""
+
+assert_exit_code() {
+  local test_name="$1"
+  local expected_code="$2"
+  local actual_code="$3"
+  if [ "$actual_code" -eq "$expected_code" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected exit $expected_code, got $actual_code\n"
+    echo "  [FAIL] $test_name (expected exit $expected_code, got $actual_code)"
+  fi
+}
+
+assert_contains() {
+  local test_name="$1"
+  local output="$2"
+  local expected="$3"
+  if echo "$output" | grep -q "$expected"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected '$expected' in output\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+assert_not_contains() {
+  local test_name="$1"
+  local output="$2"
+  local unexpected="$3"
+  if echo "$output" | grep -q "$unexpected"; then
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — unexpected '$unexpected' in output\n"
+    echo "  [FAIL] $test_name"
+  else
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  fi
+}
+
+assert_eq() {
+  local test_name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected '$expected', got '$actual'\n"
+    echo "  [FAIL] $test_name (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_gt() {
+  local test_name="$1"
+  local min="$2"
+  local actual="$3"
+  if [ "$actual" -gt "$min" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name ($actual > $min)"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — expected >$min, got $actual\n"
+    echo "  [FAIL] $test_name (expected >$min, got $actual)"
+  fi
+}
+
+assert_valid_json() {
+  local test_name="$1"
+  local filepath="$2"
+  if jq empty "$filepath" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — '$filepath' is not valid JSON\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+assert_file_exists() {
+  local test_name="$1"
+  local filepath="$2"
+  if [ -f "$filepath" ]; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $test_name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $test_name — file '$filepath' does not exist\n"
+    echo "  [FAIL] $test_name"
+  fi
+}
+
+setup() {
+  TMPDIR_BASE="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_BASE"
+}
+
+print_results() {
+  local suite_name="$1"
+  echo "========================================="
+  echo "$suite_name: $PASS passed, $FAIL failed"
+  echo "========================================="
+  if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    echo -e "$ERRORS"
+    exit 1
+  fi
+}


### PR DESCRIPTION
Fixes from three-agent code review (reuse, quality, efficiency).

### Bug Fixes
- **`migrate`**: `unset` used single quotes preventing parameter expansion — PENDING array items were never removed. Fixed to double quotes.
- **`readiness_assess`**: `find` predicates lacked grouping parentheses, so `-type f` only applied to the first `-name` pattern. Fixed with `\( ... \)`.

### Dead Code Removal
- **`readiness_assess`**: Removed 6 unused variables (`ci_status`, `ci_detail`, `test_status`, `test_detail`, `lint_status`, `lint_detail`). Inlined strings directly.
- **`spec_first_gate`**: Removed unused `upstream_stages` variable (dead jq call). Fixed misleading comment that said `<` when code does `<=`.

### Shared Library
- **`admiral/lib/assert.sh`**: Shared test helpers for future test files to source instead of copy-pasting.

### Deferred (not worth the risk/churn)
- Migrating existing 12 test files to use shared assert.sh (would touch every test)
- Extracting shared validator helpers (low frequency scripts)
- jq call batching (correctness risk, marginal perf gain for CLI tools)

All 67 affected tests still pass.