### PR TITLE
docs: mark T-08 complete (pre-existing quarantine tests)

### DIFF
--- a/plan/todo/03-testing-and-code-quality.md
+++ b/plan/todo/03-testing-and-code-quality.md
@@ -16,7 +16,7 @@
 - [x] **T-05: Add malformed JSON edge case tests for server** — Test URLs with special chars, very long URLs, concurrent requests, missing headers. Done when >=5 new edge case tests in `server.test.ts`.
 - [x] **T-06: Add hook edge case tests** — Extend `test_hooks.sh` with malformed JSON, missing jq, empty stdin, huge payloads, Unicode in tool names, concurrent execution. Done when >=10 new edge case tests, all hooks handle gracefully (fail-open per ADR-004).
 - [x] **T-07: Add `state.sh` concurrent access tests** — Test `with_state_lock` under concurrent access. Spawn multiple subshells writing to shared state. Done when flock prevents data loss under concurrent writes.
-- [ ] **T-08: Add quarantine pipeline integration tests** — Test full 5-layer quarantine pipeline with known-good and known-bad inputs end-to-end. Done when pipeline correctly quarantines all attack corpus items and passes clean items.
+- [x] **T-08: Add quarantine pipeline integration tests** — *Pre-existing: 39 tests in `admiral/monitor/quarantine/tests/test_quarantine.sh` cover all 5 layers end-to-end with attack corpus items and clean inputs.* — Test full 5-layer quarantine pipeline with known-good and known-bad inputs end-to-end. Done when pipeline correctly quarantines all attack corpus items and passes clean items.
 
 ## Coverage & Benchmarks
 


### PR DESCRIPTION
T-08 quarantine pipeline integration tests already exist: 39 tests in admiral/monitor/quarantine/tests/test_quarantine.sh covering all 5 layers with attack corpus items and clean inputs.