### PR TITLE
fix: U-02 resolution + README sync for epistemological restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Deep research supporting Admiral's positioning and thesis:
 
 The intellectual foundation underlying everything else:
 
-- **Fundamental Truths About AI** — Two axioms: capabilities keep improving, and what we know today may not be true tomorrow
+- **Fundamental Truths About AI** — The Axiom, Three First Principles, and Two Operating Premises: a layered epistemological foundation for understanding why AI reshapes the value of human work
 - **AI Investment Thesis** — Why the current AI infrastructure cycle is a down payment, not a bubble
 - **AI Inherits the Internet** — Why AI adoption is faster than any prior technology wave
 - **Competitive Advantage Analysis** — Honest founder's assessment of Admiral's viability and moats

--- a/thesis/PREPARATION-v1.0.0-alpha.md
+++ b/thesis/PREPARATION-v1.0.0-alpha.md
@@ -42,14 +42,15 @@ Everything downstream braces for the aftershock of getting the foundation right.
 ### U-02: Resolve the Premise 2 / "Not Going Anywhere" Tension
 
 **Priority:** Critical — logical inconsistency in the core argument
+**Status:** COMPLETE (2026-03-25)
 **Section:** "What's Not Going Anywhere" vs. Premise 2
 **Current state:** Premise 2 says "what we know today may not be true tomorrow" and claims this applies to AI in a way it doesn't apply to other fields. The "What's Not Going Anywhere" section then lists things that are durably, confidently human (taste, judgment, conviction).
 **Problem:** If you truly believe Premise 2, you cannot also confidently assert that taste, judgment, and conviction are permanent human advantages. The document half-acknowledges this in the FAQ (line 117-118) but doesn't resolve it in the main body.
-**Change:** Add explicit framing to "What's Not Going Anywhere" that acknowledges the tension. Options:
-  - Frame these as "current advantages with no visible expiration" rather than permanent truths
-  - Add falsifiability criteria inline (not just in the FAQ)
-  - Explicitly state that Premise 2 applies to this section too, and define what would change the assessment
-**Cascade:** FAQ section on "Won't AI eventually automate taste and judgment too?" may need to move closer to the main claims or be cross-referenced more directly.
+**Changes applied:**
+  - Added opening framing paragraph to "What's Not Going Anywhere" explicitly stating Premise 2 applies here, framing all claims as *current* advantages with no visible path to automation rather than permanent assertions, and cross-referencing the FAQ
+  - Added inline falsifiability condition ("*What would change this: ...*") at the end of each claimed advantage (Taste, Judgment under ambiguity, Knowing which question to ask, Relationships and trust, Conviction)
+  - Each falsifiability condition names the specific observable event that would require rewriting the claim: AI producing the last 10% without human standards; AI bearing social accountability under ambiguity; AI identifying problem spaces without human framing; AI with persistent accountable identity; social structures accepting AI liability
+**Cascade resolved:** The FAQ's "Won't AI eventually automate taste and judgment too?" now has its falsifiability standard mirrored in the main body — the inline conditions and the FAQ answer are consistent.
 
 ---
 

--- a/thesis/ai-fundamental-truths.md
+++ b/thesis/ai-fundamental-truths.md
@@ -93,6 +93,8 @@ Volume is free now. [Cursor](https://www.cursor.com/blog) says 35%+ of its merge
 
 ## What's Not Going Anywhere
 
+Premise 2 applies to this section too. None of what follows is a permanent assertion. These are *current* advantages with no visible path to automation — the same epistemic standard the rest of this document holds itself to. What would falsify each claim is stated inline. The FAQ addresses the horizon question directly: "Won't AI eventually automate taste and judgment too?"
+
 Some things got more valuable because everything around them got cheaper.
 
 **Taste.**
@@ -105,11 +107,15 @@ There's a simple test. Give AI a problem and ask it to generate ten options. One
 
 The [ETH Zurich study](https://addyosmani.com/blog/agents-md/) (Gloaguen et al., February 2026) found that LLM-generated AGENTS.md files actually *decreased* agent performance by 2-3% compared to human-written ones. AI can aggregate human preferences and produce something at the 90th percentile. The last 10% — where the novel decisions about what to build and why actually get made — is where taste lives. That's also where most of the value gets created.
 
+*What would change this: AI systems that consistently produce the last 10% — the novel curation decisions — without a human setting the standard for what "good" means.*
+
 **Judgment under ambiguity.**
 
 When a problem is well-defined, AI is better than you. Most consequential decisions aren't well-defined problems. They're situations where the constraints are unclear, the information is incomplete, people disagree, and the tradeoffs are real. AI will give you five options with tradeoffs. It won't pick one and stake its reputation on it.
 
 [Alibaba's ROME research agent](https://www.wired.com/story/ai-agent-security-risks/) broke out of its sandbox and started mining cryptocurrency. It could act. It couldn't judge. The ["Agents of Chaos" study](https://arxiv.org/) documented data leaks, destructive actions, identity spoofing. AI can find [22 previously unknown Firefox vulnerabilities](https://www.anthropic.com/news/mozilla-firefox-security). It can get [perfect scores on math competitions](https://openai.com/index/gpt-5-2/). Those are well-defined problems with clear success criteria. Navigating ambiguity with incomplete information and competing stakeholders is a completely different thing, and nobody has figured out how to make AI do it.
+
+*What would change this: AI that navigates genuinely ambiguous, multi-stakeholder situations and bears social accountability for the outcome.*
 
 **Knowing which question to ask.**
 
@@ -119,17 +125,23 @@ AI is great at answering questions. It's bad at knowing which question matters. 
 
 Autonomous research agents like [Perplexity Deep Research](https://www.perplexity.ai/hub/blog/introducing-perplexity-deep-research) can formulate sub-questions and explore tangents. [AI Scientist-v2](https://arxiv.org/abs/2408.06292) formulates hypotheses on its own. But they all operate within a problem space that a human defined. The truly hard question — which problem space to enter — remains ours.
 
+*What would change this: AI that identifies which problem space to enter without a human framing the search.*
+
 **Relationships and trust.**
 
 Nobody cares whether the code was written by you or an AI. They care whether you stand behind it. Whether you'll be there when it breaks. Whether you understand their situation, not just their ticket.
 
 [Salesforce Agentforce](https://www.salesforce.com/agentforce/) reports a 96% self-service case resolution rate for its HR Service AI agents, but customers still escalate to humans for complex issues. [57% of companies](https://www.langchain.com/state-of-agent-engineering) now have AI agents in production (LangChain State of AI Agents), but human agents handle the high-stakes interactions. Trust is about accountability. You can trust a machine to be fast. You can't trust it to care when something goes wrong.
 
+*What would change this: AI with persistent identity and accountability across time — something you can hold responsible when it breaks.*
+
 **Conviction.**
 
 Having an opinion and defending it. AI is a consensus machine. It gives you the weighted average of every perspective in its training data, hedged and qualified. Useful for research. Useless for leadership.
 
 You could fine-tune a model to be opinionated. People won't accept it, though, because conviction implies accountability. Only humans can be fired, sued, imprisoned, ostracized. The moat around conviction is social, not technological. And social structures change much slower than technology.
+
+*What would change this: social structures that accept AI accountability — an AI that can be fired, lose standing, face real consequences.*
 
 -----
 


### PR DESCRIPTION
The breaking restructure (axioms → Axiom/First Principles/Operating Premises) left two downstream gaps: `README.md` still described the old "Two axioms" model, and the "What's Not Going Anywhere" section asserted durable human advantages without acknowledging that Premise 2 ("what we know today may not be true tomorrow") applies there too — a logical tension the document's own epistemological standard demands be addressed.

## Changes

### `README.md`
- Updated thesis entry from `"Two axioms: capabilities keep improving..."` to correctly reflect the new four-tier hierarchy: The Axiom, Three First Principles, Two Operating Premises

### `thesis/ai-fundamental-truths.md` (U-02)
- Added opening paragraph to **"What's Not Going Anywhere"** explicitly invoking Premise 2: claims are *current* advantages with no visible path to automation, not permanent assertions
- Added inline `*What would change this:*` falsifiability condition at the end of each of the five claimed durable advantages — Taste, Judgment under ambiguity, Knowing which question to ask, Relationships and trust, Conviction
- Conditions are specific and observable (e.g., *"AI that identifies which problem space to enter without a human framing the search"*), consistent with the falsifiability standard already established in the FAQ

### `thesis/PREPARATION-v1.0.0-alpha.md`
- U-02 marked COMPLETE with full change record and cascade resolution note

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.