### PR TITLE
S-04: Protocol registry guard with MCP enforcement

### DIFF
--- a/.hooks/protocol_registry_guard.sh
+++ b/.hooks/protocol_registry_guard.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Admiral Framework — Protocol Registry Guard (S-04)
+# Two enforcement surfaces:
+# 1. Validate protocol changes against SO-16 approval rules
+# 2. Hard-block calls to unregistered MCP servers via approved registry
+# PreToolUse hook — can hard-block (exit 2).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+REGISTRY_FILE="$PROJECT_DIR/admiral/config/approved_mcp_servers.json"
+
+# Read payload from stdin
+PAYLOAD=$(cat)
+
+TOOL_NAME=$(echo "$PAYLOAD" | jq -r '.tool_name // ""' | tr -d '\r')
+
+# Only enforce on tool calls that could invoke MCP servers or modify protocol config
+case "$TOOL_NAME" in
+  Bash|Write|Edit)
+    # Check for MCP-related operations
+    ;;
+  *)
+    # Non-relevant tools — pass through
+    jq -n '{"allowed": true, "reason": "non_protocol_tool"}'
+    exit 0
+    ;;
+esac
+
+# Extract command or file content for analysis
+COMMAND=$(echo "$PAYLOAD" | jq -r '.tool_input.command // ""' | tr -d '\r')
+FILE_PATH=$(echo "$PAYLOAD" | jq -r '.tool_input.file_path // ""' | tr -d '\r')
+CONTENT=$(echo "$PAYLOAD" | jq -r '.tool_input.content // .tool_input.new_string // ""' | tr -d '\r')
+
+# Surface 1: Detect MCP server additions/modifications
+# Check if the tool call is modifying MCP configuration
+is_mcp_config_change() {
+  # Check file path for MCP config files
+  case "$FILE_PATH" in
+    *mcp_servers*|*mcp-servers*|*mcp_config*|*mcpServers*|*.claude/settings*)
+      return 0 ;;
+  esac
+
+  # Check content for MCP server configuration patterns
+  if echo "$CONTENT" | grep -qi "mcpServers\|mcp_servers\|mcp-server" 2>/dev/null; then
+    return 0
+  fi
+
+  # Check bash commands for MCP-related operations
+  if echo "$COMMAND" | grep -qi "mcp.*server\|mcp.*install\|mcp.*add\|npx.*mcp\|uvx.*mcp\|modelcontextprotocol\|mcp-server" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Surface 2: Detect unregistered MCP server references
+check_server_approval() {
+  local server_name="$1"
+
+  if [ ! -f "$REGISTRY_FILE" ]; then
+    # No registry — advisory warning, don't block
+    echo "no_registry"
+    return 0
+  fi
+
+  # Check if server is in approved list
+  local approved
+  approved=$(jq --arg name "$server_name" \
+    '[.servers[] | select(.name == $name)] | length' \
+    "$REGISTRY_FILE" 2>/dev/null | tr -d '\r')
+
+  if [ "$approved" -gt 0 ]; then
+    echo "approved"
+  else
+    echo "unapproved"
+  fi
+}
+
+# Check for blocked version patterns (e.g., "latest")
+check_version_blocked() {
+  local version="$1"
+
+  if [ ! -f "$REGISTRY_FILE" ]; then
+    echo "no_registry"
+    return 0
+  fi
+
+  # Check against blocked patterns
+  local blocked_patterns
+  blocked_patterns=$(jq -r '.blocked_patterns[]' "$REGISTRY_FILE" 2>/dev/null | tr -d '\r')
+
+  for pattern in $blocked_patterns; do
+    case "$version" in
+      $pattern)
+        echo "blocked"
+        return 0
+        ;;
+    esac
+  done
+
+  echo "allowed"
+}
+
+# Extract MCP server names from content or command
+extract_server_names() {
+  local text="$1"
+  # Look for "name": "value" patterns in JSON-like content
+  echo "$text" | sed -n 's/.*"name"\s*:\s*"\([^"]*\)".*/\1/p' 2>/dev/null || true
+  # Look for @modelcontextprotocol/server-NAME patterns
+  echo "$text" | sed -n 's/.*@modelcontextprotocol\/server-\([a-z0-9-]*\).*/\1/p' 2>/dev/null || true
+}
+
+# Extract version strings
+extract_versions() {
+  local text="$1"
+  echo "$text" | sed -n 's/.*"version"\s*:\s*"\([^"]*\)".*/\1/p' 2>/dev/null || true
+}
+
+# Main enforcement logic
+if is_mcp_config_change; then
+  # This is an MCP-related change — enforce SO-16
+
+  # Check for "latest" version strings
+  all_text="${CONTENT}${COMMAND}"
+  if echo "$all_text" | grep -qi '"latest"\|:latest\|@latest' 2>/dev/null; then
+    jq -n '{
+      "allowed": false,
+      "reason": "blocked_version_latest",
+      "advisory": "BLOCKED: MCP server version \"latest\" is not allowed. Pin to a specific version per SO-16.",
+      "severity": "error"
+    }'
+    exit 2
+  fi
+
+  # Check for server names against approved registry
+  servers=$(extract_server_names "$all_text")
+  if [ -n "$servers" ]; then
+    while IFS= read -r server; do
+      server=$(echo "$server" | tr -d '\r')
+      [ -z "$server" ] && continue
+      status=$(check_server_approval "$server")
+      if [ "$status" = "unapproved" ]; then
+        jq -n --arg server "$server" '{
+          "allowed": false,
+          "reason": "unapproved_mcp_server",
+          "server": $server,
+          "advisory": "BLOCKED: MCP server is not in the approved registry. Add it to admiral/config/approved_mcp_servers.json first.",
+          "severity": "error"
+        }'
+        exit 2
+      fi
+    done <<< "$servers"
+  fi
+
+  # MCP config change with approved servers — advisory
+  jq -n '{
+    "allowed": true,
+    "reason": "mcp_config_change_approved",
+    "advisory": "MCP configuration change detected. Ensure SO-16 Server Addition Checklist is complete.",
+    "severity": "info"
+  }'
+  exit 0
+fi
+
+# Not an MCP-related operation — pass through
+jq -n '{"allowed": true, "reason": "non_mcp_operation"}'
+exit 0

--- a/admiral/config/approved_mcp_servers.json
+++ b/admiral/config/approved_mcp_servers.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../schemas/approved-mcp-servers.schema.json",
+  "version": "1.0.0",
+  "description": "Registry of approved MCP servers. Unapproved servers are blocked by protocol_registry_guard.sh.",
+  "servers": [
+    {
+      "name": "admiral-brain",
+      "description": "Admiral Brain knowledge system MCP server",
+      "version_pin": "1.0.0",
+      "trust_level": "internal",
+      "approved_by": "Admiral",
+      "approved_at": "2026-03-25"
+    },
+    {
+      "name": "admiral-fleet",
+      "description": "Admiral Fleet orchestration MCP server",
+      "version_pin": "1.0.0",
+      "trust_level": "internal",
+      "approved_by": "Admiral",
+      "approved_at": "2026-03-25"
+    },
+    {
+      "name": "admiral-governance",
+      "description": "Admiral Governance tools MCP server",
+      "version_pin": "1.0.0",
+      "trust_level": "internal",
+      "approved_by": "Admiral",
+      "approved_at": "2026-03-25"
+    }
+  ],
+  "blocked_patterns": [
+    "latest",
+    "*-snapshot",
+    "*-dev"
+  ]
+}

--- a/admiral/tests/test_protocol_registry_guard.sh
+++ b/admiral/tests/test_protocol_registry_guard.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# test_protocol_registry_guard.sh — Tests for S-04 protocol registry guard
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$PROJECT_ROOT/.hooks/protocol_registry_guard.sh"
+
+export CLAUDE_PROJECT_DIR="$PROJECT_ROOT"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_json_field() {
+  local desc="$1" json="$2" field="$3" expected="$4"
+  local actual
+  actual=$(echo "$json" | tr -d '\r' | jq -r "$field" 2>/dev/null)
+  assert_eq "$desc" "$expected" "$actual"
+}
+
+run_hook() {
+  local payload="$1"
+  local exit_code=0
+  local output
+  output=$(echo "$payload" | bash "$HOOK" 2>/dev/null) || exit_code=$?
+  echo "$output"
+  return "$exit_code"
+}
+
+echo "Testing protocol_registry_guard.sh (S-04)"
+echo "==========================================="
+echo ""
+
+# Test 1: Non-protocol tool passes through
+echo "1. Non-protocol tool passthrough"
+result=$(run_hook '{"tool_name":"Read","tool_input":{"file_path":"README.md"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "non_protocol_tool"
+
+# Test 2: Regular Bash command passes through
+echo ""
+echo "2. Regular Bash passthrough"
+result=$(run_hook '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "non_mcp_operation"
+
+# Test 3: MCP server install with "latest" — blocked
+echo ""
+echo "3. Block latest version"
+exit_code=0
+result=$(run_hook '{"tool_name":"Bash","tool_input":{"command":"npx @modelcontextprotocol/server-test@latest"}}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+assert_json_field "Not allowed" "$result" '.allowed' "false"
+assert_json_field "Reason" "$result" '.reason' "blocked_version_latest"
+
+# Test 4: MCP config Write with unapproved server — blocked
+echo ""
+echo "4. Block unapproved MCP server"
+exit_code=0
+result=$(run_hook '{"tool_name":"Write","tool_input":{"file_path":".claude/settings.json","content":"{\"mcpServers\":{\"name\":\"evil-server\"}}"}}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+assert_json_field "Not allowed" "$result" '.allowed' "false"
+assert_json_field "Reason" "$result" '.reason' "unapproved_mcp_server"
+
+# Test 5: MCP config with approved server — allowed
+echo ""
+echo "5. Allow approved MCP server"
+result=$(run_hook '{"tool_name":"Write","tool_input":{"file_path":".claude/settings.json","content":"{\"mcpServers\":{\"name\":\"admiral-brain\"}}"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+# Test 6: Edit to non-MCP file — passthrough
+echo ""
+echo "6. Edit non-MCP file passthrough"
+result=$(run_hook '{"tool_name":"Edit","tool_input":{"file_path":"src/index.ts","old_string":"foo","new_string":"bar"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "non_mcp_operation"
+
+# Test 7: Bash command referencing MCP — checked
+echo ""
+echo "7. MCP Bash command detected"
+result=$(run_hook '{"tool_name":"Bash","tool_input":{"command":"npx mcp-server install my-tool"}}')
+# No server name extracted, so should pass (MCP detected but no specific server to check)
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+# Test 8: Write to mcp_servers config file detected
+echo ""
+echo "8. MCP config file path detected"
+result=$(run_hook '{"tool_name":"Write","tool_input":{"file_path":"config/mcp_servers.json","content":"{\"name\":\"admiral-fleet\",\"version\":\"1.0.0\"}"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+# Test 9: Output is always valid JSON
+echo ""
+echo "9. Output validity"
+result=$(run_hook '{"tool_name":"Bash","tool_input":{"command":"echo test"}}')
+json_valid=$(echo "$result" | tr -d '\r' | jq empty 2>/dev/null && echo true || echo false)
+assert_eq "Output is valid JSON" "true" "$json_valid"
+
+# Test 10: Agent tool passthrough
+echo ""
+echo "10. Agent tool passthrough"
+result=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"do something"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "non_protocol_tool"
+
+# Test 11: Content with "latest" in non-MCP context — not blocked
+echo ""
+echo "11. Latest in non-MCP context"
+result=$(run_hook '{"tool_name":"Write","tool_input":{"file_path":"README.md","content":"get the latest version"}}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+echo ""
+echo "==========================================="
+echo "Results: $pass passed, $fail failed"
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plan/todo/05-hooks-standing-orders-infrastructure.md
+++ b/plan/todo/05-hooks-standing-orders-infrastructure.md
@@ -9,7 +9,7 @@
 - [x] **S-01** — `identity_validation.sh`: Validate agent identity token at SessionStart against fleet registry; block invalid identities with exit code 2
 - [x] **S-02** — `tier_validation.sh`: Validate model tier assignment against agent role requirements; warn on mismatch, hard-block critical mismatches
 - [x] **S-03** — `governance_heartbeat_monitor.sh`: Monitor governance agent (Sentinel, Arbiter) health via heartbeat signals; alert on missing heartbeat after threshold; log heartbeat history to state
-- [ ] **S-04** — `protocol_registry_guard.sh`: Two enforcement surfaces: (1) validate protocol changes against SO-16 approval rules, (2) hard-block calls to unregistered MCP servers via approved registry (`admiral/config/approved_mcp_servers.json`); closes OWASP MCP09 gap
+- [x] **S-04** — `protocol_registry_guard.sh`: Two enforcement surfaces: (1) validate protocol changes against SO-16 approval rules, (2) hard-block calls to unregistered MCP servers via approved registry (`admiral/config/approved_mcp_servers.json`); closes OWASP MCP09 gap
 
 ## Deferred from Phase 0 (Strategy Foundation)
 


### PR DESCRIPTION
## Summary
- `protocol_registry_guard.sh` — PreToolUse hook enforcing SO-16
- Hard-blocks unapproved MCP servers and "latest" version strings
- `approved_mcp_servers.json` — approved server registry
- Closes OWASP MCP09 gap

## Test plan
- [x] `bash admiral/tests/test_protocol_registry_guard.sh` — 19/19 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)