### PR TITLE
S-08: Tool permission matrix

### DIFF
--- a/.hooks/tool_permission_guard.sh
+++ b/.hooks/tool_permission_guard.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Admiral Framework — Tool Permission Guard (S-08)
+# Enforces per-agent tool permissions from fleet registry.
+# PreToolUse hook — hard-blocks denied tools (exit 2).
+# If no agent_id in session, passes through (single-agent mode).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Source libraries
+source "$PROJECT_DIR/admiral/lib/state.sh"
+source "$PROJECT_DIR/admiral/lib/agent_registry.sh"
+
+# Read payload from stdin
+PAYLOAD=$(cat)
+
+TOOL_NAME=$(echo "$PAYLOAD" | jq -r '.tool_name // ""' | tr -d '\r')
+
+# Get current agent_id from session state
+_state=$(load_state)
+AGENT_ID=$(echo "$_state" | jq -r '.agent_id // ""' | tr -d '\r')
+
+# If no agent_id, single-agent mode — pass through
+if [ -z "$AGENT_ID" ] || [ "$AGENT_ID" = "null" ]; then
+  jq -n '{"allowed": true, "reason": "single_agent_mode"}'
+  exit 0
+fi
+
+# If no tool name, pass through
+if [ -z "$TOOL_NAME" ] || [ "$TOOL_NAME" = "null" ]; then
+  jq -n '{"allowed": true, "reason": "no_tool_name"}'
+  exit 0
+fi
+
+# Initialize registry and look up agent
+registry_init
+AGENT_DEF=$(registry_get_agent "$AGENT_ID")
+
+if [ -z "$AGENT_DEF" ]; then
+  # Unregistered agent — advisory, don't block
+  jq -n --arg agent "$AGENT_ID" --arg tool "$TOOL_NAME" '{
+    "allowed": true,
+    "reason": "unregistered_agent",
+    "advisory": "Agent not in registry — tool permissions not enforced.",
+    "severity": "warning"
+  }'
+  exit 0
+fi
+
+# Check if tool is explicitly denied
+IS_DENIED=$(registry_agent_tool_denied "$AGENT_ID" "$TOOL_NAME")
+
+if [ "$IS_DENIED" = "true" ]; then
+  ROLE=$(echo "$AGENT_DEF" | jq -r '.role' | tr -d '\r')
+  jq -n --arg agent "$AGENT_ID" --arg tool "$TOOL_NAME" --arg role "$ROLE" '{
+    "allowed": false,
+    "reason": "tool_denied",
+    "agent_id": $agent,
+    "role": $role,
+    "tool": $tool,
+    "advisory": "BLOCKED: Tool is denied for this agent role. Check fleet_registry.json for allowed tools.",
+    "severity": "error"
+  }'
+  exit 2
+fi
+
+# Check if tool is in allowed list (if allowed list is non-empty)
+IS_ALLOWED=$(registry_agent_has_tool "$AGENT_ID" "$TOOL_NAME")
+ALLOWED_COUNT=$(echo "$AGENT_DEF" | jq '.tools.allowed | length' | tr -d '\r')
+
+if [ "$ALLOWED_COUNT" -gt 0 ] && [ "$IS_ALLOWED" = "false" ]; then
+  # Tool not in allowed list and list is non-empty — soft warning
+  ROLE=$(echo "$AGENT_DEF" | jq -r '.role' | tr -d '\r')
+  jq -n --arg agent "$AGENT_ID" --arg tool "$TOOL_NAME" --arg role "$ROLE" '{
+    "allowed": true,
+    "reason": "tool_not_in_allowlist",
+    "agent_id": $agent,
+    "role": $role,
+    "tool": $tool,
+    "advisory": "Tool not in agent allowed list. Proceeding but capabilities may be limited.",
+    "severity": "warning"
+  }'
+  exit 0
+fi
+
+# Tool is allowed
+jq -n --arg agent "$AGENT_ID" --arg tool "$TOOL_NAME" '{
+  "allowed": true,
+  "agent_id": $agent,
+  "tool": $tool,
+  "reason": "tool_permitted"
+}'
+exit 0

--- a/admiral/tests/test_tool_permission_guard.sh
+++ b/admiral/tests/test_tool_permission_guard.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# test_tool_permission_guard.sh — Tests for S-08 tool permission matrix
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$PROJECT_ROOT/.hooks/tool_permission_guard.sh"
+STATE_DIR="$PROJECT_ROOT/.admiral"
+STATE_FILE="$STATE_DIR/session_state.json"
+
+export CLAUDE_PROJECT_DIR="$PROJECT_ROOT"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_json_field() {
+  local desc="$1" json="$2" field="$3" expected="$4"
+  local actual
+  actual=$(echo "$json" | tr -d '\r' | jq -r "$field" 2>/dev/null)
+  assert_eq "$desc" "$expected" "$actual"
+}
+
+setup_state() {
+  local agent_id="$1"
+  mkdir -p "$STATE_DIR"
+  jq -n --arg aid "$agent_id" '{session_id: "perm-test", agent_id: $aid, tool_uses: 1, hook_state: {}}' > "$STATE_FILE"
+}
+
+cleanup() {
+  rm -f "$STATE_FILE" 2>/dev/null || true
+}
+
+run_hook() {
+  local payload="$1"
+  local exit_code=0
+  local output
+  output=$(echo "$payload" | bash "$HOOK" 2>/dev/null) || exit_code=$?
+  echo "$output"
+  return "$exit_code"
+}
+
+echo "Testing tool_permission_guard.sh (S-08)"
+echo "========================================"
+echo ""
+
+# Test 1: No agent_id — single agent mode
+echo "1. No agent_id (single-agent passthrough)"
+setup_state ""
+result=$(run_hook '{"tool_name":"Bash"}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "single_agent_mode"
+
+# Test 2: Orchestrator using allowed tool (Read)
+echo ""
+echo "2. Orchestrator using allowed tool"
+setup_state "orchestrator"
+result=$(run_hook '{"tool_name":"Read"}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "tool_permitted"
+
+# Test 3: Orchestrator using denied tool (Write)
+echo ""
+echo "3. Orchestrator using denied tool (Write)"
+setup_state "orchestrator"
+exit_code=0
+result=$(run_hook '{"tool_name":"Write"}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+assert_json_field "Not allowed" "$result" '.allowed' "false"
+assert_json_field "Reason" "$result" '.reason' "tool_denied"
+
+# Test 4: Backend implementer using allowed tool (Bash)
+echo ""
+echo "4. Backend implementer using allowed tool"
+setup_state "backend-implementer"
+result=$(run_hook '{"tool_name":"Bash"}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "tool_permitted"
+
+# Test 5: QA agent using denied tool (Write)
+echo ""
+echo "5. QA agent using denied tool"
+setup_state "qa-agent"
+exit_code=0
+result=$(run_hook '{"tool_name":"Write"}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+assert_json_field "Not allowed" "$result" '.allowed' "false"
+assert_json_field "QA role identified" "$result" '.role' "qa"
+
+# Test 6: Security auditor using denied tool (Edit)
+echo ""
+echo "6. Security auditor denied Edit"
+setup_state "security-auditor"
+exit_code=0
+result=$(run_hook '{"tool_name":"Edit"}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+assert_json_field "Not allowed" "$result" '.allowed' "false"
+
+# Test 7: Unregistered agent — advisory, not blocked
+echo ""
+echo "7. Unregistered agent passthrough"
+setup_state "phantom-agent"
+result=$(run_hook '{"tool_name":"Bash"}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+assert_json_field "Reason" "$result" '.reason' "unregistered_agent"
+assert_json_field "Warning" "$result" '.severity' "warning"
+
+# Test 8: Triage agent using denied tool (Bash)
+echo ""
+echo "8. Triage agent denied Bash"
+setup_state "triage-agent"
+exit_code=0
+result=$(run_hook '{"tool_name":"Bash"}') || exit_code=$?
+assert_eq "Exit code 2 (blocked)" "2" "$exit_code"
+
+# Test 9: Triage agent using allowed tool (Read)
+echo ""
+echo "9. Triage agent allowed Read"
+setup_state "triage-agent"
+result=$(run_hook '{"tool_name":"Read"}')
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+# Test 10: Output is always valid JSON
+echo ""
+echo "10. Output validity"
+setup_state "orchestrator"
+result=$(run_hook '{"tool_name":"Read"}')
+json_valid=$(echo "$result" | tr -d '\r' | jq empty 2>/dev/null && echo true || echo false)
+assert_eq "Output is valid JSON" "true" "$json_valid"
+
+# Test 11: Tool not in allowlist but not denied — warning
+echo ""
+echo "11. Tool not in allowlist (warning only)"
+setup_state "orchestrator"
+result=$(run_hook '{"tool_name":"WebFetch"}')
+# WebFetch is not in orchestrator's allowed or denied list — should warn
+assert_json_field "Allowed" "$result" '.allowed' "true"
+
+cleanup
+
+echo ""
+echo "========================================"
+echo "Results: $pass passed, $fail failed"
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plan/todo/05-hooks-standing-orders-infrastructure.md
+++ b/plan/todo/05-hooks-standing-orders-infrastructure.md
@@ -28,7 +28,7 @@
 
 - [x] **S-06** — Agent registry: Runtime registry mapping agent ID to capabilities, routing rules, model tier, and tool permissions; provides lookup API (by ID, capability, tier); returns structured JSON
 - [ ] **S-07** — Task routing engine: Route tasks to agents based on task type, file ownership, capability scores, and load; return routing decision with justification
-- [ ] **S-08** — Tool permission matrix: Per-agent tool permissions enforced at runtime; denied tools blocked with clear error; integrates with `pre_tool_use_adapter.sh`
+- [x] **S-08** — Tool permission matrix: Per-agent tool permissions enforced at runtime; denied tools blocked with clear error; integrates with `pre_tool_use_adapter.sh`
 - [ ] **S-09** — Fleet configuration validator: Validate fleet config against spec constraints (1-12 agents, no tool list overlap, no routing conflicts, valid tiers); pre-flight check before deployment
 
 ## Execution Patterns (Stream 8, Section 8.1)


### PR DESCRIPTION
## Summary
- `tool_permission_guard.sh` — per-agent tool permissions from fleet registry
- Hard-blocks denied tools, warns on unlisted tools
- Single-agent mode passthrough

## Test plan
- [x] `bash admiral/tests/test_tool_permission_guard.sh` — 21/21 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)