### PR TITLE
B-01: Automatic brain entry creation from hooks

### DIFF
--- a/.hooks/loop_detector.sh
+++ b/.hooks/loop_detector.sh
@@ -19,6 +19,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 
+# Source brain writer for automatic entry creation (B-01)
+if [ -f "$PROJECT_DIR/admiral/lib/brain_writer.sh" ]; then
+  source "$PROJECT_DIR/admiral/lib/brain_writer.sh"
+fi
+
 source "$PROJECT_DIR/admiral/lib/state.sh"
 
 # Load thresholds from central config, falling back to hardcoded defaults
@@ -96,6 +101,10 @@ LOOP_STATE=$(echo "$LOOP_STATE" | jq \
 # Check thresholds — emit advisory alerts, NEVER block
 if [ "$NEW_COUNT" -ge "$MAX_SAME_ERROR" ]; then
   ALERT+="LOOP WARNING: Error signature '${SIG}' repeated ${NEW_COUNT} times. Consider recovery ladder (SO-06). Try a different approach. "
+    # Record pattern to Brain (B-01)
+    if type brain_record_pattern &>/dev/null; then
+      brain_record_pattern "loop_detector" "error_loop" "Signature $SIG repeated $NEW_COUNT times"
+    fi
 fi
 
 if [ "$NEW_TOTAL" -ge "$MAX_TOTAL_ERRORS" ]; then

--- a/.hooks/prohibitions_enforcer.sh
+++ b/.hooks/prohibitions_enforcer.sh
@@ -11,6 +11,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 
+# Source brain writer for automatic entry creation (B-01)
+if [ -f "$PROJECT_DIR/admiral/lib/brain_writer.sh" ]; then
+  source "$PROJECT_DIR/admiral/lib/brain_writer.sh"
+fi
+
 # Read payload from stdin
 PAYLOAD=$(cat)
 
@@ -144,6 +149,10 @@ fi
 
 # Emit output based on severity
 if [ "$HARD_BLOCK" = "true" ]; then
+  # Record violation to Brain (B-01)
+  if type brain_record_violation &>/dev/null; then
+    brain_record_violation "prohibitions_enforcer" "hard_block" "$ALERTS" "$TOOL_NAME"
+  fi
   jq -n --arg ctx "$ALERTS" '{
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",

--- a/.hooks/scope_boundary_guard.sh
+++ b/.hooks/scope_boundary_guard.sh
@@ -13,6 +13,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 
+# Source brain writer for automatic entry creation (B-01)
+if [ -f "$PROJECT_DIR/admiral/lib/brain_writer.sh" ]; then
+  source "$PROJECT_DIR/admiral/lib/brain_writer.sh"
+fi
+
 # Read payload from stdin
 PAYLOAD=$(cat)
 
@@ -145,6 +150,10 @@ fi
 
 # No override — hard-block the write
 BLOCK_MSG="SCOPE BOUNDARY (SO-03): Write to protected path '${MATCHED_DIR}' is BLOCKED. This path requires Admiral approval. Options: (1) Ask the Admiral to set ADMIRAL_SCOPE_OVERRIDE=${MATCHED_DIR%/} for this session, (2) Escalate with justification, (3) Work on non-protected paths instead."
+# Record violation to Brain (B-01)
+if type brain_record_violation &>/dev/null; then
+  brain_record_violation "scope_boundary_guard" "scope_violation" "Write to protected path: ${MATCHED_DIR}" "${TOOL_NAME:-unknown}"
+fi
 jq -n --arg ctx "$BLOCK_MSG" '{
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",

--- a/admiral/lib/brain_writer.sh
+++ b/admiral/lib/brain_writer.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Admiral Framework — Brain Writer Library (B-01)
+# Provides functions for hooks to automatically create brain entries.
+# Called by enforcement hooks to record decisions, violations, patterns.
+
+BRAIN_WRITER_PROJECT="${BRAIN_WRITER_PROJECT:-helm}"
+
+# Write a brain entry from a hook. Non-blocking — failures are logged, not raised.
+# Usage: brain_write <category> <title> <content> [source_hook]
+brain_write() {
+  local category="$1"
+  local title="$2"
+  local content="$3"
+  local source_hook="${4:-hook}"
+
+  local project_dir="${CLAUDE_PROJECT_DIR:-.}"
+  local brain_record="$project_dir/admiral/bin/brain_record"
+
+  if [ ! -x "$brain_record" ]; then
+    return 0
+  fi
+
+  # Non-blocking: run in background, suppress errors
+  "$brain_record" "$BRAIN_WRITER_PROJECT" "$category" "$title" "$content" "$source_hook" 2>/dev/null || true
+}
+
+# Record a policy violation (from prohibitions_enforcer, scope_boundary_guard)
+brain_record_violation() {
+  local hook_name="$1"
+  local violation_type="$2"
+  local details="$3"
+  local tool_name="${4:-unknown}"
+
+  brain_write "failure" \
+    "Policy violation: $violation_type" \
+    "Hook: $hook_name. Tool: $tool_name. $details" \
+    "$hook_name"
+}
+
+# Record a pattern detection (from loop_detector, context_health_check)
+brain_record_pattern() {
+  local hook_name="$1"
+  local pattern_name="$2"
+  local details="$3"
+
+  brain_write "pattern" \
+    "Pattern detected: $pattern_name" \
+    "Hook: $hook_name. $details" \
+    "$hook_name"
+}
+
+# Record a decision made by a hook
+brain_record_decision() {
+  local hook_name="$1"
+  local decision="$2"
+  local rationale="$3"
+
+  brain_write "decision" \
+    "$decision" \
+    "Hook: $hook_name. Rationale: $rationale" \
+    "$hook_name"
+}
+
+# Record a lesson learned from hook outcomes
+brain_record_lesson() {
+  local hook_name="$1"
+  local lesson="$2"
+  local context="$3"
+
+  brain_write "lesson" \
+    "$lesson" \
+    "Hook: $hook_name. Context: $context" \
+    "$hook_name"
+}

--- a/admiral/tests/test_brain_writer.sh
+++ b/admiral/tests/test_brain_writer.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# test_brain_writer.sh — Tests for B-01 automatic brain entry creation
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+export CLAUDE_PROJECT_DIR="$PROJECT_ROOT"
+export BRAIN_DIR="$PROJECT_ROOT/.brain"
+
+# Source brain writer
+source "$PROJECT_ROOT/admiral/lib/brain_writer.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+# Setup test brain directory
+TEST_PROJECT="test-brain-writer"
+export BRAIN_WRITER_PROJECT="$TEST_PROJECT"
+TEST_BRAIN_DIR="$BRAIN_DIR/$TEST_PROJECT"
+
+cleanup() {
+  rm -rf "$TEST_BRAIN_DIR" 2>/dev/null || true
+}
+
+cleanup
+
+echo "Testing brain_writer.sh (B-01)"
+echo "==============================="
+echo ""
+
+# Test 1: brain_write creates an entry
+echo "1. Basic brain_write"
+brain_write "decision" "Test decision" "This is a test decision" "test_hook"
+entry_count=$(ls "$TEST_BRAIN_DIR"/*decision* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Decision entry created" "true" "$([ "$entry_count" -ge 1 ] && echo true || echo false)"
+
+# Test 2: Entry is valid JSON
+echo ""
+echo "2. Entry is valid JSON"
+latest=$(ls -t "$TEST_BRAIN_DIR"/*.json 2>/dev/null | head -1)
+if [ -n "$latest" ]; then
+  json_valid=$(jq empty "$latest" 2>/dev/null && echo true || echo false)
+  assert_eq "Entry is valid JSON" "true" "$json_valid"
+
+  # Check required fields
+  has_title=$(jq 'has("title")' "$latest" | tr -d '\r')
+  assert_eq "Entry has title" "true" "$has_title"
+  has_content=$(jq 'has("content")' "$latest" | tr -d '\r')
+  assert_eq "Entry has content" "true" "$has_content"
+  has_category=$(jq 'has("category")' "$latest" | tr -d '\r')
+  assert_eq "Entry has category" "true" "$has_category"
+else
+  echo "  FAIL: No entry file found"
+  fail=$((fail + 1))
+fi
+
+# Test 3: brain_record_violation creates a failure entry
+echo ""
+echo "3. Record violation"
+brain_record_violation "prohibitions_enforcer" "bypass_pattern" "Attempted --no-verify" "Bash"
+failure_count=$(ls "$TEST_BRAIN_DIR"/*failure* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Failure entry created" "true" "$([ "$failure_count" -ge 1 ] && echo true || echo false)"
+
+# Test 4: brain_record_pattern creates a pattern entry
+echo ""
+echo "4. Record pattern"
+brain_record_pattern "loop_detector" "error_loop" "Same error 3 times"
+pattern_count=$(ls "$TEST_BRAIN_DIR"/*pattern* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Pattern entry created" "true" "$([ "$pattern_count" -ge 1 ] && echo true || echo false)"
+
+# Test 5: brain_record_decision creates a decision entry
+echo ""
+echo "5. Record decision"
+brain_record_decision "tier_validation" "Block security on tier3" "Security auditor requires tier1"
+decision_count=$(ls "$TEST_BRAIN_DIR"/*decision* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Multiple decisions created" "true" "$([ "$decision_count" -ge 2 ] && echo true || echo false)"
+
+# Test 6: brain_record_lesson creates a lesson entry
+echo ""
+echo "6. Record lesson"
+brain_record_lesson "scope_boundary_guard" "Protected paths prevent accidents" "Caught write to aiStrat/"
+lesson_count=$(ls "$TEST_BRAIN_DIR"/*lesson* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Lesson entry created" "true" "$([ "$lesson_count" -ge 1 ] && echo true || echo false)"
+
+# Test 7: Entries have correct source agent
+echo ""
+echo "7. Source agent tracking"
+latest_violation=$(ls -t "$TEST_BRAIN_DIR"/*failure* 2>/dev/null | head -1)
+if [ -n "$latest_violation" ]; then
+  source_agent=$(jq -r '.source_agent' "$latest_violation" | tr -d '\r')
+  assert_eq "Source agent recorded" "prohibitions_enforcer" "$source_agent"
+else
+  echo "  FAIL: No violation file found"
+  fail=$((fail + 1))
+fi
+
+# Test 8: Non-blocking on failure (brain_record missing)
+echo ""
+echo "8. Non-blocking on failure"
+# Temporarily rename brain_record
+BRAIN_RECORD="$PROJECT_ROOT/admiral/bin/brain_record"
+mv "$BRAIN_RECORD" "${BRAIN_RECORD}.bak"
+# This should not error despite brain_record being missing
+brain_write "decision" "Should not crash" "Testing resilience" "test"
+exit_code=$?
+assert_eq "Exit code 0 despite missing brain_record" "0" "$exit_code"
+mv "${BRAIN_RECORD}.bak" "$BRAIN_RECORD"
+
+# Test 9: Total entries created
+echo ""
+echo "9. Total entries"
+total=$(ls "$TEST_BRAIN_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Multiple entries created" "true" "$([ "$total" -ge 5 ] && echo true || echo false)"
+
+cleanup
+
+echo ""
+echo "==============================="
+echo "Results: $pass passed, $fail failed"
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -12,7 +12,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 
 ## B1 Completion
 
-- [ ] **B-01** Automatic brain entry creation from hooks — `brain_writer.sh` library called by `prohibitions_enforcer.sh`, `loop_detector.sh`, `scope_boundary_guard.sh`
+- [x] **B-01** Automatic brain entry creation from hooks — `brain_writer.sh` library called by `prohibitions_enforcer.sh`, `loop_detector.sh`, `scope_boundary_guard.sh`
 - [ ] **B-02** Brain retrieval in hooks — `brain_context_router.sh` actively queries Brain, injects matching entries as structured context on Propose/Escalate-tier calls
 - [ ] **B-03** Demand signal tracking — record zero-result queries to `.brain/_demand/`, expose via `brain_audit --demand`
 - [ ] **B-04** Contradiction scan on write — keyword overlap detection, warning with conflicting entry paths, non-blocking (entry still written with `contradicts` metadata)


### PR DESCRIPTION
## Summary
- `brain_writer.sh` library for hooks to auto-create brain entries
- Integrated into prohibitions_enforcer, scope_boundary_guard, loop_detector
- Non-blocking, resilient to missing brain_record

## Test plan
- [x] `bash admiral/tests/test_brain_writer.sh` — 12/12 passing
- [x] `bash admiral/tests/test_session_start_adapter.sh` — 15/15 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)