### PR TITLE
B-03: Demand signal tracking

### DIFF
--- a/admiral/bin/brain_audit
+++ b/admiral/bin/brain_audit
@@ -1,22 +1,65 @@
 #!/bin/bash
 # Admiral Framework — Brain Audit (B1)
 # Lists entries older than 90 days (decay awareness)
-# Usage: brain_audit [--project <name>] [--days <N>]
+# Usage: brain_audit [--project <name>] [--days <N>] [--demand]
 set -euo pipefail
 
 BRAIN_DIR="${BRAIN_DIR:-${CLAUDE_PROJECT_DIR:-.}/.brain}"
 
 DECAY_DAYS=90
 PROJECT=""
+SHOW_DEMAND=false
 
 # Parse flags
 while [ $# -gt 0 ]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
     --days) DECAY_DAYS="$2"; shift 2 ;;
+    --demand) SHOW_DEMAND=true; shift ;;
     *) shift ;;
   esac
 done
+
+# B-03: Demand signal report
+if [ "$SHOW_DEMAND" = "true" ]; then
+  DEMAND_DIR="$BRAIN_DIR/_demand"
+  echo "Brain Demand Signal Report"
+  echo "=========================="
+  echo ""
+
+  if [ ! -d "$DEMAND_DIR" ]; then
+    echo "No demand signals recorded."
+    echo ""
+    echo "Total demand signals: 0"
+    exit 0
+  fi
+
+  DEMAND_COUNT=0
+  DEMAND_FILES=$(find "$DEMAND_DIR" -name "*.json" -type f 2>/dev/null | sort -r)
+  for file in $DEMAND_FILES; do
+    [ -f "$file" ] || continue
+    DEMAND_COUNT=$((DEMAND_COUNT + 1))
+    KW=$(jq -r '.keyword' "$file" 2>/dev/null)
+    TS=$(jq -r '.timestamp' "$file" 2>/dev/null)
+    PROJ=$(jq -r '.project // "any"' "$file" 2>/dev/null)
+    echo "  [$TS] \"$KW\" (project: $PROJ)"
+  done
+
+  echo ""
+  echo "=========================="
+  echo "Total demand signals: $DEMAND_COUNT"
+
+  if [ "$DEMAND_COUNT" -gt 0 ]; then
+    echo ""
+    echo "Top requested keywords:"
+    find "$DEMAND_DIR" -name "*.json" -type f -exec jq -r '.keyword' {} \; 2>/dev/null | \
+      sort | uniq -c | sort -rn | head -10 | \
+      while read -r count keyword; do
+        echo "  $count x \"$keyword\""
+      done
+  fi
+  exit 0
+fi
 
 SEARCH_PATH="$BRAIN_DIR"
 if [ -n "$PROJECT" ]; then

--- a/admiral/lib/brain_retriever.sh
+++ b/admiral/lib/brain_retriever.sh
@@ -3,6 +3,30 @@
 # Provides functions for hooks to query Brain and get structured context.
 # Used by brain_context_router.sh to inject matching entries on Propose/Escalate.
 
+# Record a demand signal when a query returns zero results (B-03)
+_record_demand_signal() {
+  local keyword="$1"
+  local project="${2:-}"
+  local demand_dir="${BRAIN_DIR:-${CLAUDE_PROJECT_DIR:-.}/.brain}/_demand"
+
+  mkdir -p "$demand_dir" 2>/dev/null || return 0
+
+  local ts
+  ts=$(date -u +%Y%m%d-%H%M%S 2>/dev/null || echo "unknown")
+  local iso_ts
+  iso_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+
+  local filename="${ts}-demand-${keyword}.json"
+  # Sanitize filename
+  filename=$(echo "$filename" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
+  jq -n --arg kw "$keyword" \
+        --arg proj "$project" \
+        --arg ts "$iso_ts" \
+        '{keyword: $kw, project: $proj, timestamp: $ts, type: "demand_signal"}' \
+        > "$demand_dir/$filename" 2>/dev/null || true
+}
+
 # Query brain for entries matching a keyword. Returns JSON array of matches.
 # Usage: brain_retrieve_context <keyword> [project] [max_results]
 brain_retrieve_context() {
@@ -33,6 +57,8 @@ brain_retrieve_context() {
   matching_files=$(grep -rlFi "$keyword" "$search_path" 2>/dev/null | head -n "$max_results" || true)
 
   if [ -z "$matching_files" ]; then
+    # B-03: Record demand signal for zero-result queries
+    _record_demand_signal "$keyword" "$project"
     echo "[]"
     return 0
   fi

--- a/admiral/tests/test_demand_signals.sh
+++ b/admiral/tests/test_demand_signals.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# test_demand_signals.sh — Tests for B-03 demand signal tracking
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+export CLAUDE_PROJECT_DIR="$PROJECT_ROOT"
+export BRAIN_DIR="$PROJECT_ROOT/.brain"
+
+DEMAND_DIR="$BRAIN_DIR/_demand"
+BRAIN_AUDIT="$PROJECT_ROOT/admiral/bin/brain_audit"
+
+# Source brain retriever
+source "$PROJECT_ROOT/admiral/lib/brain_retriever.sh"
+
+pass=0
+fail=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc (expected '$expected', got '$actual')"
+    fail=$((fail + 1))
+  fi
+}
+
+cleanup() {
+  rm -rf "$DEMAND_DIR" 2>/dev/null || true
+}
+
+cleanup
+
+echo "Testing demand signal tracking (B-03)"
+echo "======================================="
+echo ""
+
+# Test 1: Zero-result query creates demand signal
+echo "1. Zero-result query creates demand signal"
+result=$(brain_retrieve_context "zzz_totally_nonexistent_topic_12345" "" 3)
+signal_count=$(ls "$DEMAND_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Demand signal created" "true" "$([ "$signal_count" -ge 1 ] && echo true || echo false)"
+
+# Test 2: Demand signal is valid JSON
+echo ""
+echo "2. Demand signal is valid JSON"
+latest=$(ls -t "$DEMAND_DIR"/*.json 2>/dev/null | head -1)
+if [ -n "$latest" ]; then
+  json_valid=$(jq empty "$latest" 2>/dev/null && echo true || echo false)
+  assert_eq "Signal is valid JSON" "true" "$json_valid"
+  has_keyword=$(jq 'has("keyword")' "$latest" | tr -d '\r')
+  assert_eq "Signal has keyword" "true" "$has_keyword"
+  has_ts=$(jq 'has("timestamp")' "$latest" | tr -d '\r')
+  assert_eq "Signal has timestamp" "true" "$has_ts"
+  has_type=$(jq 'has("type")' "$latest" | tr -d '\r')
+  assert_eq "Signal has type" "true" "$has_type"
+  signal_type=$(jq -r '.type' "$latest" | tr -d '\r')
+  assert_eq "Type is demand_signal" "demand_signal" "$signal_type"
+else
+  echo "  FAIL: No signal file found"
+  fail=$((fail + 4))
+fi
+
+# Test 3: Multiple queries create multiple signals
+echo ""
+echo "3. Multiple demand signals"
+brain_retrieve_context "another_nonexistent_topic_xyz" "" 3 > /dev/null
+brain_retrieve_context "yet_another_missing_topic_abc" "" 3 > /dev/null
+signal_count=$(ls "$DEMAND_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "Multiple signals created" "true" "$([ "$signal_count" -ge 3 ] && echo true || echo false)"
+
+# Test 4: Successful query does NOT create demand signal
+echo ""
+echo "4. Successful query no demand signal"
+before_count=$(ls "$DEMAND_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+brain_retrieve_context "adapter" "helm" 3 > /dev/null
+after_count=$(ls "$DEMAND_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "No new signal on success" "$before_count" "$after_count"
+
+# Test 5: brain_audit --demand works
+echo ""
+echo "5. brain_audit --demand"
+output=$(bash "$BRAIN_AUDIT" --demand 2>&1)
+assert_eq "Demand report runs" "true" "$(echo "$output" | grep -q "Demand Signal Report" && echo true || echo false)"
+assert_eq "Shows signal count" "true" "$(echo "$output" | grep -q "Total demand signals:" && echo true || echo false)"
+
+# Test 6: brain_audit --demand with no signals
+echo ""
+echo "6. Empty demand report"
+cleanup
+output=$(bash "$BRAIN_AUDIT" --demand 2>&1)
+assert_eq "Reports zero signals" "true" "$(echo "$output" | grep -q "Total demand signals: 0" && echo true || echo false)"
+
+cleanup
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -14,7 +14,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 
 - [x] **B-01** Automatic brain entry creation from hooks — `brain_writer.sh` library called by `prohibitions_enforcer.sh`, `loop_detector.sh`, `scope_boundary_guard.sh`
 - [x] **B-02** Brain retrieval in hooks — `brain_context_router.sh` actively queries Brain, injects matching entries as structured context on Propose/Escalate-tier calls
-- [ ] **B-03** Demand signal tracking — record zero-result queries to `.brain/_demand/`, expose via `brain_audit --demand`
+- [x] **B-03** Demand signal tracking — record zero-result queries to `.brain/_demand/`, expose via `brain_audit --demand`
 - [ ] **B-04** Contradiction scan on write — keyword overlap detection, warning with conflicting entry paths, non-blocking (entry still written with `contradicts` metadata)
 - [ ] **B-05** Brain entry consolidation — `brain_consolidate` utility merges overlapping entries with provenance, archives originals to `.brain/_archived/`
 - [ ] **B-06** Brain B1 comprehensive tests — 20+ tests covering all utilities, edge cases (empty brain, special chars, long content), concurrent access


### PR DESCRIPTION
## Summary
- Records zero-result brain queries as demand signals in `.brain/_demand/`
- `brain_audit --demand` shows demand report with top requested keywords
- Identifies knowledge gaps in the Brain

## Test plan
- [x] `bash admiral/tests/test_demand_signals.sh` — 11/11 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)