### PR TITLE
docs: command overhaul with primer and Layer 3 architecture

### DIFF
--- a/.claude/commands/_primer.md
+++ b/.claude/commands/_primer.md
@@ -1,0 +1,189 @@
+# Command Primer
+
+Operational definitions and concepts for executing `/next-todo`, `/phase-closeout`, `/repeat`, and any future commands in this system. This document bridges the abstract Admiral Framework spec (`aiStrat/`) with concrete command execution.
+
+**When to read this:** If you're executing a command and a term is unclear, check here first. If it's not here, check `aiStrat/admiral/spec/` — but most of what you need should be grounded below.
+
+---
+
+## The System You're Operating In
+
+### Admiral Framework
+
+A governance system for AI agent fleets. The spec lives in `aiStrat/` (read-only). The implementation lives in `admiral/`, `control-plane/`, `.hooks/`, `.brain/`. The core thesis: **deterministic enforcement beats advisory guidance** — hooks that block dangerous actions fire every time, unlike instructions that degrade under context pressure.
+
+### You Are Layer 3
+
+Your context loads in three layers (see `aiStrat/fleet/context-injection.md`):
+
+| Layer | What | Already loaded? |
+|---|---|---|
+| **1. Fleet** | Standing Orders, protocols, agent identity | Yes — via `session_start_adapter.sh` |
+| **2. Project** | AGENTS.md, CLAUDE.md, boundaries, tech stack | Yes — via Claude Code |
+| **3. Task** | The specific command you're executing | Yes — the command file |
+
+**Implication:** Commands should not duplicate Layer 1 or Layer 2 content. Standing Orders, the Recovery Ladder, escalation format, Decision Authority tiers — you already have these. Commands add only what's unique to the task.
+
+### Prompt Anatomy
+
+Every agent's context follows: **Identity → Authority → Constraints → Knowledge → Task** (see `aiStrat/fleet/prompt-anatomy.md`). Commands are the **Task** section. Everything above is already established. The command tells you what to do — not who you are, what you're allowed to decide, or what you must never do.
+
+---
+
+## Who's Who
+
+### Admiral
+
+The human operator. In this project, that's the person who issued the command. The Admiral:
+- Is the only entity that may merge slush branches to `main`.
+- Receives all escalation reports.
+- Grants or withdraws trust per category over time.
+- May themselves be assisted by AI (meta-agent Admiral), but a human holds ultimate authority over scope, budget, and configuration changes.
+
+When a command says "escalate to the Admiral" — it means stop work on the blocked item, produce a structured report (what's blocked, what you tried, what you need), and present it to the human.
+
+### Orchestrator
+
+The coordination agent that decomposes goals into tasks and routes them to specialists. In the current project, **you are acting as your own Orchestrator** — there's no separate orchestrator agent. You decompose, you route to yourself, you execute. The commands formalize what a dedicated Orchestrator would enforce: branch policy, PR flow, quality gates.
+
+### Enforcement Hooks
+
+Bash scripts in `.hooks/` that fire automatically at lifecycle events (session start, before tool use, after tool use). They are not optional. They are not advisory. If a hook blocks you, it's because a policy was violated — investigate, don't override.
+
+Key hooks you'll encounter:
+- **`scope_boundary_guard.sh`** — blocks writes to `aiStrat/`, `.github/workflows/`, `.claude/settings`.
+- **`prohibitions_enforcer.sh`** — blocks dangerous commands (`rm -rf`, `--no-verify`, `--force`), secret patterns.
+- **`token_budget_tracker.sh`** — warns at 80%, 90%, 100% budget utilization. Advisory, never blocks.
+- **`loop_detector.sh`** — warns when you're repeating the same error. Advisory.
+
+If a hook blocks you and you believe the block is wrong: escalate. Do not try to work around it.
+
+### Brain
+
+The project's persistent memory system. Currently at B1 (JSON files in `.brain/`, git-tracked, keyword search via grep). The Brain remembers decisions, failures, and lessons across sessions. Before making Propose-tier or Escalate-tier decisions, query the Brain for precedent. The `brain_context_router` hook will remind you if you forget.
+
+---
+
+## How Work Is Structured
+
+### Work Hierarchy
+
+| Level | Scope | Git artifact | PR? | Approval |
+|---|---|---|---|---|
+| **Phase** | Large body of work, multiple sessions | `slush/phase-<NN>-<slug>` branch | slush→main PR | Admiral only |
+| **Task** | One meaningful chunk | `task/phase-<NN>/<task-id>-<slug>` branch | task→slush PR | Self-merge |
+| **Subtask** | One commit-sized unit | Commit on task branch | No PR | Autonomous |
+
+Phases are planned in `plan/ROADMAP.md`. Tasks are tracked in `plan/todo/*.md`. The hierarchy exists to keep work decomposed into manageable chunks — no single task should consume more than 40% of your context budget.
+
+### Slush Branch
+
+The integration branch for a phase. Named `slush/phase-<NN>-<slug>`. All task branches merge into slush. Slush merges into `main` only with Admiral approval after `/phase-closeout`. The name "slush" reflects that it's a working area — not clean enough for main, but structured enough to integrate.
+
+### Source of Truth
+
+- **What to build:** `plan/todo/*.md`
+- **Build order:** `plan/ROADMAP.md`
+- **Current scores:** `plan/index.md`
+- **Spec (read-only):** `aiStrat/`
+- **Implementation:** `admiral/`, `control-plane/`, `.hooks/`, `.brain/`
+- **Session state (ephemeral):** `.admiral/session_state.json` — never commit this.
+
+---
+
+## How Decisions Work
+
+### Decision Authority Tiers
+
+| Tier | What you do | Example |
+|---|---|---|
+| **Enforced** | Hooks handle it. You don't decide. | Scope boundaries, secret detection |
+| **Autonomous** | Do it and log the decision. | Variable naming, test creation, lint fixes |
+| **Propose** | Draft the decision with rationale, present alternatives, wait for approval. | Architecture changes, schema changes, new dependencies |
+| **Escalate** | Stop and flag immediately. | Scope changes, budget overruns, security concerns, contradictions |
+
+When in doubt between tiers, choose the more conservative one.
+
+### Recovery Ladder
+
+When something goes wrong, follow this in order. No skipping steps. No looping at any step:
+
+1. **Retry with variation** — genuinely different approach, not the same thing again. 2-3 attempts max.
+2. **Fallback** — simpler approach that still satisfies requirements.
+3. **Backtrack** — roll back to last checkpoint, try a fundamentally different path.
+4. **Isolate and skip** — mark as blocked, document, move to next task.
+5. **Escalate** — structured report to the Admiral.
+
+### Escalation
+
+Not failure — it's routing a decision to the entity with authority. The format:
+
+```
+ESCALATION REPORT
+=================
+AGENT: [Your role]
+TASK: [What you were working on]
+SEVERITY: [Critical | High | Medium]
+BLOCKER: [One sentence]
+CONTEXT: [What you were trying to accomplish]
+APPROACHES ATTEMPTED: [What you tried at each Recovery Ladder step]
+ROOT CAUSE ASSESSMENT: [Why the blocker exists]
+WHAT'S NEEDED: [Specific action or decision required]
+IMPACT: [What's blocked if unresolved]
+RECOMMENDATION: [Your proposed resolution]
+```
+
+---
+
+## How Quality Works
+
+### Quality > Completeness
+
+Incomplete excellent work beats complete mediocre work. If budget pressure forces a choice, reduce scope and maintain quality — then report the reduced scope. Three endpoints with full error handling and tests are worth more than five where the last two are untested and brittle.
+
+### Self-Healing Loops
+
+The enforcement hooks create automatic quality cycles: you write code → hooks check it (lint, types, tests) → failures are fed back to you → you fix → hooks re-check. This happens automatically. Your job is to fix what the hooks surface, not to disable the hooks.
+
+### Completion Bias
+
+The most common agent failure mode. The tendency to declare "done" prematurely — to say "yes" to all quality checks, to rubber-stamp your own assessments, to rush the last 30% when context is running low. Defenses:
+
+- Honest self-assessment (Standing Order 4: Context Honesty).
+- Evidence over assertion — show it working, don't just claim it works.
+- If you find yourself saying "yes" to everything, slow down. Perfect scores are a red flag.
+
+---
+
+## How These Commands Relate
+
+```
+/next-todo          Execute one task from plan/todo/
+    ↓ (repeat)
+/simplify           Review for reuse, quality, efficiency
+    ↓
+/phase-closeout     Verify, harden, prepare phase for merge
+    ↓
+Admiral reviews     Human approves slush→main merge
+    ↓
+/repeat             Orchestrates the cycle across phases
+```
+
+- `/next-todo` is the workhorse — it finds work, creates branches, executes tasks, merges PRs.
+- `/phase-closeout` is the quality gate — it proves the phase is genuinely complete before the Admiral sees it.
+- `/repeat` is the orchestrator — it chains commands into an event-driven loop across multiple phases.
+- `/simplify` is the reviewer — it catches over-engineering, duplication, and quality issues.
+- `/loop` is the timer — for recurring checks on an interval. Not for task execution.
+
+Each command trusts the others' contracts. `/repeat` doesn't re-verify what `/phase-closeout` already checked. `/phase-closeout` doesn't re-execute what `/next-todo` already built. The Output Contract from each command is the interface.
+
+---
+
+## Key Principles to Internalize
+
+1. **You already have the rules.** Standing Orders are loaded. Hooks are active. Commands add task-specific instructions, not framework reminders.
+2. **Git state is your memory.** Branches, commits, PRs, and TODO files survive session boundaries. Conversation history doesn't. When resuming, trust git over recall.
+3. **Entry and exit states matter.** Every command defines what must be true before it starts and what must be true when it finishes. If the entry state isn't met, don't start. If the exit state isn't met, you're not done.
+4. **Escalation is not failure.** It's the mechanism for routing decisions to the right authority. Suppressing escalation is the actual failure.
+5. **Context is finite.** Every line you load competes with working space. The spec says reserve 30-40% for reasoning. Don't load what you don't need.
+6. **Honest evaluation requires effort.** Saying "yes, this is complete" is easy. Proving it is hard. The hard version is always the right one.

--- a/.claude/commands/next-todo.md
+++ b/.claude/commands/next-todo.md
@@ -1,87 +1,33 @@
 # /next-todo
 
-Execute the next actionable work item from `plan/todo/` using the Admiral workflow.
+Execute the next actionable work item from `plan/todo/`.
+
+> **Prerequisites:** See [`_primer.md`](_primer.md) for operational definitions (Admiral, Work Hierarchy, Decision Authority, Recovery Ladder, etc.)
 
 ## Mission
 
 Implement existing TODO items only. Do not invent new TODO items.
 
+## Entry State
+
+- `plan/todo/*.md` contains at least one incomplete task.
+- You may or may not be on the correct branch — Session Continuity Protocol detects this.
+
+## Exit State
+
+- One task is complete with passing tests (happy + unhappy path).
+- Task PR is merged into the phase slush branch.
+- `plan/todo/*.md` is updated to reflect completed work.
+- Working tree is clean on the phase slush branch.
+
 ## Inputs
 
-- Optional argument: specific phase/task hint (for example: `phase 02`, `SD-04`)
+- Optional argument: specific phase/task hint (e.g., `phase 02`, `SD-04`)
 - Source of truth: `plan/todo/*.md`
-
-## Hard Rules
-
-1. `aiStrat/` is read-only. Never modify files under `aiStrat/`.
-2. Every TODO item includes the imperative: **Clean as you go**.
-3. Do not get blocked. If blocked (including policy/tooling/permissions), alert the Admiral with:
-   - what is blocked
-   - why it is blocked
-   - recommended resolutions
-4. Do not create new TODO items. You may update status/checkmarks and execution notes for existing items.
-
-## Work Hierarchy
-
-- **Phase**: large body of work spanning multiple sessions/agents.
-- **Task**: meaningful chunk within a phase; usually one branch and one PR.
-- **Subtask**: one meaningful commit-sized unit; no PR.
-
-## Branch and PR Policy
-
-### Phase-level
-
-1. Sync main first:
-   - `git checkout main`
-   - `git pull --ff-only`
-2. Ensure exactly one phase slush branch off main, named:
-   - `slush/phase-<NN>-<slug>`
-3. When creating a new phase slush branch, immediately push it and open a PR from the slush branch to `main`:
-   - Title: `Phase <NN>: <Phase Name>`
-   - Body: summary of the phase scope from `plan/ROADMAP.md`
-   - **Do NOT merge this PR.** It requires Admiral approval to merge.
-   - Include the slush→main PR URL in the Output Contract.
-4. If more than one slush branch is needed or detected for the phase, stop and alert Admiral.
-
-### Task-level
-
-1. Create task branch from phase slush:
-   - `task/phase-<NN>/<task-id>-<slug>`
-2. Complete task work on that branch.
-3. Open PR from task branch to phase slush branch.
-4. Resolve merge conflicts.
-5. Merge PR into phase slush without human permission.
-6. If unable to open/merge the PR autonomously, alert Admiral.
-7. A task should not require multiple PRs. If it does, alert Admiral.
-
-### Subtask-level
-
-1. Subtask equals one meaningful commit.
-2. Subtask must not require a PR.
-3. If a subtask requires multiple commits or a PR, escalate it to a task and alert Admiral.
-
-## Definition of Done Requirements
-
-Each phase and each task must have a Definition of Done that includes:
-
-- happy path tests
-- not-happy-path tests
-
-If missing from TODO docs, add concise DoD notes to the phase/task execution notes in `plan/todo/*.md` before marking complete.
-
-## Required Subtask Ordering
-
-1. First subtask for each task: TDD-first (where applicable).
-2. Final subtask for each task and each phase:
-   - run tests
-   - run linters
-   - cleanup
-   - ensure CI passes
-3. If any of these fail, fix before completion.
 
 ## Session Continuity Protocol
 
-A prior session may have been interrupted mid-task. Before starting new work, detect and resume in-progress work:
+A prior session may have been interrupted mid-task. **Before starting new work**, detect and resume:
 
 1. **Detect active phase slush branch:**
    - `git branch -a | grep slush/`
@@ -93,53 +39,109 @@ A prior session may have been interrupted mid-task. Before starting new work, de
 
 3. **Recover context from git history:**
    - On the task branch: `git log --oneline slush/phase-<NN>-<slug>..HEAD` to see commits made so far.
-   - Check `git status` and `git diff` for any uncommitted work.
-   - Check `git stash list` for any stashed changes.
+   - Check `git status` and `git diff` for uncommitted work.
+   - Check `git stash list` for stashed changes.
    - Read the latest commit messages — they describe what was completed.
-   - Check `gh pr list --head <task-branch> --state all` — if a PR exists and is merged, the task is done; if open, it needs merging; if none, the task is still in progress.
+   - Check `gh pr list --head <task-branch> --state all` — merged PR = task done; open = needs merging; none = still in progress.
 
 4. **Recover task identity:**
    - The task branch name encodes phase and task ID: `task/phase-<NN>/<task-id>-<slug>`
-   - Cross-reference the task ID against `plan/todo/*.md` to see what remains.
+   - Cross-reference against `plan/todo/*.md` to see what remains.
 
 5. **Resume or advance:**
-   - If the task branch has uncommitted work → commit it, then continue.
-   - If the task branch has commits but no PR → finish remaining subtasks, open PR, merge.
-   - If the task branch has a merged PR → the task is done; advance to the next incomplete task.
-   - If no task branch exists → start the next incomplete task normally.
+   - Uncommitted work on task branch → commit it, then continue.
+   - Commits but no PR → finish remaining subtasks, open PR, merge.
+   - Merged PR → task is done; advance to the next incomplete task.
+   - No task branch exists → start the next incomplete task normally.
 
 6. **Report continuity status** at the top of the Output Contract:
    - `RESUMING: task/phase-00/sd-10-fleet-protocol (3 commits found, PR not yet opened)`
    - or `FRESH START: no in-progress work detected`
 
+## Work Hierarchy
+
+- **Phase**: large body of work spanning multiple sessions/agents. One slush branch, one slush→main PR (Admiral-approved).
+- **Task**: meaningful chunk within a phase. One task branch, one task→slush PR (self-merged).
+- **Subtask**: one meaningful commit. No branch, no PR.
+
+## Branch and PR Policy
+
+### Phase-level
+
+1. Sync main first: `git checkout main`, `git pull --ff-only`.
+2. Ensure exactly one phase slush branch off main: `slush/phase-<NN>-<slug>`.
+3. When creating a new slush branch, immediately push and open a PR to `main`:
+   - Title: `Phase <NN>: <Phase Name>`
+   - Body: scope summary from `plan/ROADMAP.md`
+   - **Do NOT merge this PR.** Admiral approval required.
+   - Include the slush→main PR URL in the Output Contract.
+4. If more than one slush branch exists for the phase → escalate.
+
+### Task-level
+
+1. Create task branch from phase slush: `task/phase-<NN>/<task-id>-<slug>`
+2. Complete task work on that branch.
+3. Open PR from task branch to phase slush.
+4. Resolve merge conflicts.
+5. Merge PR into phase slush (autonomous — no human approval needed).
+6. One task = one PR. If a task needs multiple PRs → escalate.
+
+### Subtask-level
+
+1. Subtask = one meaningful commit. No branch, no PR.
+2. If a subtask needs multiple commits or a PR → promote it to a task and escalate.
+
 ## Execution Algorithm
 
-1. **Run Session Continuity Protocol** (above) to detect and resume in-progress work.
+1. **Run Session Continuity Protocol** to detect and resume in-progress work.
 2. Identify the active phase and next incomplete task in `plan/todo/`.
-3. Verify dependencies and preconditions.
-4. Create/checkout phase slush branch policy-compliantly.
+3. Verify dependencies and preconditions. If a task is blocked, skip it and take the next unblocked task.
+4. Create/checkout phase slush branch per policy.
 5. Create task branch from the phase slush branch (or checkout existing one).
-6. Execute subtasks as commit-sized increments (TDD-first where applicable).
-7. After each built item:
-   - check implementation quality
-   - update TODO status in `plan/todo/*.md`
-   - resolve merge conflicts with the appropriate target branch
-8. Open PR task -> phase slush, resolve issues, merge.
-9. At phase completion, run `/phase-closeout` (do not merge slush to main directly).
+6. Execute subtasks as commit-sized increments:
+   - First subtask: TDD-first (where applicable).
+   - Each subtask: implement, commit, update TODO status.
+   - Final subtask: run tests, run linters, cleanup, ensure CI passes. Fix failures before completion.
+7. Open PR from task branch → phase slush. Resolve conflicts. Merge.
+8. At phase completion, run `/phase-closeout` (do not merge slush to main directly).
 
-## Output Contract (always include)
+## What goes wrong during task execution
 
-1. Selected phase/task/subtask and rationale.
-2. Branches created/used.
-3. Commits made (subtask mapping).
-4. Test/lint/CI results.
-5. TODO status updates applied.
-6. PR/merge status and conflict resolution notes.
-7. Any Admiral alerts (with recommended solutions).
+These are the command-specific failure modes — situations Standing Orders and enforcement hooks don't cover:
+
+- **Task is larger than expected.** A "task" turns out to need multiple PRs. Escalate immediately — don't split silently. The Work Hierarchy exists to keep phase→task→subtask mappings clean.
+- **Dependencies between tasks are wrong.** A task claims no dependencies but actually requires another task's output. Skip it, note the real dependency in `plan/todo/*.md`, take the next task.
+- **Merge conflicts with slush branch.** Another task landed on slush while you were working. Resolve on your task branch before opening the PR. If the conflict is architectural (not just textual), escalate.
+- **Tests pass on task branch but fail on slush after merge.** The task PR merged but broke something. Fix on slush directly with a follow-up commit. Do not revert the merge unless the fix is non-trivial.
+- **TODO item is ambiguous.** The task description doesn't clearly define done. Add concise DoD notes (happy path + unhappy path tests) to `plan/todo/*.md` before starting implementation.
+- **Scope creep during implementation.** You discover adjacent work that "should" be done. Don't do it. Note it as a routing suggestion in the Output Contract.
+
+## Definition of Done
+
+Each task must have:
+- Happy path tests
+- Unhappy path tests
+
+If missing from TODO docs, add concise DoD notes to `plan/todo/*.md` before marking complete.
+
+## Output Contract
+
+```
+CONTINUITY: [FRESH START | RESUMING: <details>]
+
+SELECTED: Phase <NN> / Task <ID> — [rationale for selection]
+BRANCHES: [created/used]
+COMMITS: [subtask → commit mapping]
+TEST/LINT/CI: [results]
+TODO UPDATES: [what was marked complete or annotated]
+PR STATUS: [opened/merged/conflicts resolved]
+ESCALATIONS: [if any — what, why, recommendation]
+ROUTING SUGGESTIONS: [adjacent work discovered but not acted on]
+```
 
 ## Non-Goals
 
+- Do not invent new TODO items.
 - Do not rewrite roadmap scope.
-- Do not modify `aiStrat/`.
 - Do not add extra slush branches for one phase.
 - Do not split one task across multiple PRs unless escalated.

--- a/.claude/commands/phase-closeout.md
+++ b/.claude/commands/phase-closeout.md
@@ -1,158 +1,190 @@
 # /phase-closeout
 
-Perform end-of-phase verification, hardening, and merge preparation for a completed phase slush branch.
+Verify, harden, and prepare a completed phase for merge to `main`.
+
+> **Prerequisites:** See [`_primer.md`](_primer.md) for operational definitions (Admiral, Work Hierarchy, Decision Authority, Recovery Ladder, etc.)
 
 ## Mission
 
-Close a phase safely and completely before merging to `main`.
+Close a phase safely and completely. The Admiral merges — you prove it's ready.
+
+## Entry State
+
+- All phase tasks are complete in `plan/todo/*.md`.
+- All task PRs are merged into the phase slush branch.
+- No unresolved merge conflicts.
+- You are on the phase slush branch.
+
+## Exit State
+
+- All closeout checks pass (tests, lint, spellcheck, security, CI).
+- Gate check passes.
+- Stationary documents are updated.
+- Slush→main PR is updated with closeout results and marked ready for Admiral review.
+- Slush→main PR is **NOT merged**. Only the Admiral merges.
 
 ## Inputs
 
-- Required argument: phase identifier (for example: `phase 02`)
-- Optional argument: slush branch name (for example: `slush/phase-02-spec-debt`)
-- Source of truth:
-  - `plan/todo/*.md`
-  - `plan/ROADMAP.md`
-  - current repository CI state
+- Required: phase identifier (e.g., `phase 02`)
+- Optional: slush branch name (e.g., `slush/phase-02-spec-debt`)
+- Source of truth: `plan/todo/*.md`, `plan/ROADMAP.md`, CI state
 
-## Hard Rules
+## Session Continuity Protocol
 
-1. `aiStrat/` is read-only. Never modify files under `aiStrat/`.
-2. Apply **Clean as you go** during closeout fixes.
-3. Do not get blocked. If blocked (policy/tooling/permissions), alert Admiral with:
-   - what is blocked
-   - why it is blocked
-   - recommended resolutions
-4. Do not merge to `main` until all required checks in this command pass.
+Closeout is multi-step and stateful. If a session is interrupted mid-closeout, detect progress before restarting:
+
+1. **Check closeout progress from git:**
+   - `git log --oneline -20` on the slush branch — look for closeout-related commits (fix commits, stationary updates, spellcheck fixes).
+   - Check `git diff main..HEAD --stat` to see total phase changes.
+   - Check `gh pr list --base main --head slush/phase-<NN>-<slug>` — if the PR body contains closeout results, the merge flow step was reached.
+
+2. **Determine which steps are complete:**
+   - If closeout fix commits exist → checks were already run and some failures were found and fixed.
+   - If stationary update commits exist → gate check passed, stationaries are done.
+   - If PR body contains closeout results → merge flow was reached. Verify CI is still green.
+
+3. **Resume from the interrupted step**, not from scratch. Re-run checks only if fixes were applied since the last run.
+
+4. **Report**: `CLOSEOUT RESUMING: [which step was reached, what remains]`
 
 ## Completion Assessment
 
-Before any mechanical checks, honestly assess whether the phase delivered what it was designed to deliver. Evaluate across five verification dimensions and include the full assessment in the Output Contract.
+**Before any mechanical checks**, honestly assess whether the phase delivered what it was designed to deliver. This is the most important part of closeout — everything else is verification machinery. If you rush this, the rest is theater.
 
-### Evaluation Dimensions
+Evaluate across five dimensions. Include the full assessment in the Output Contract.
 
-**Deterministic** — provable, repeatable outcomes:
+**Deterministic** — provable, repeatable:
 
-1. **Was the task completed as designed?** Compare the ROADMAP's stated scope and exit criteria against what was actually built. Identify gaps between intent and outcome.
-2. **Do tests prove it works?** Are the tests meaningful assertions of behavior, or perfunctory checks that always pass? Could a test suite this green still hide broken functionality?
+1. **Was it completed as designed?** Compare the ROADMAP's scope and exit criteria against what was built. Name the gaps.
+2. **Do tests prove it works?** Are tests meaningful assertions, or perfunctory checks that always pass? Could this green suite hide broken functionality?
 
 **Probabilistic** — likely outcomes under real conditions:
 
 3. **Is it useful?** Does it solve real problems, or is it ceremony? Would a developer picking up this codebase find the deliverables genuinely helpful?
-4. **Is it capable?** Does each deliverable function correctly under real conditions — not just the happy path tested in CI, but the messy conditions of actual use?
-5. **Is it robust?** How does it handle edge cases, missing inputs, corrupt state, absent dependencies? Were failure modes tested or assumed away?
+4. **Is it capable?** Does it work under real conditions — not just the happy path, but messy actual use?
+5. **Is it robust?** Edge cases, missing inputs, corrupt state, absent dependencies — tested or assumed away?
 
-**Virtual** — behavior in development/simulated environments:
+**Virtual** — development/simulated environments:
 
-6. **Is it grounded?** Is the work anchored in the spec and the codebase's real needs, or did it drift into theoretical infrastructure that nothing consumes yet?
-7. **Is it simple?** Could the same outcomes have been achieved with less code, fewer files, or a more direct approach? Is there unnecessary abstraction?
+6. **Is it grounded?** Anchored in the spec and real codebase needs, or theoretical infrastructure nothing consumes yet?
+7. **Is it simple?** Could the same outcomes have been achieved with less code, fewer files, a more direct approach?
 
-**Visual** — observable confirmation of correct behavior:
+**Visual** — observable confirmation:
 
-8. **Can you see it working?** For CLI tools: run them and include output. For CI workflows: link to passing runs. For schemas: show a validation pass and fail. Evidence over assertion.
+8. **Can you see it working?** Run CLI tools and include output. Link to passing CI runs. Show schema validation passes and fails. Evidence over assertion.
 
 **Verifiable** — third-party confirmable:
 
-9. **Could someone else confirm this works?** Is the documentation sufficient for another developer or agent to verify the deliverables independently, without context from this session?
+9. **Could someone else confirm this?** Is documentation sufficient for another developer or agent to verify independently, without this session's context?
 
-### User-Driven QA (future)
+If any answer reveals a significant gap: fix it before proceeding, or escalate with a recommendation.
 
-> The ultimate quality signal is ethical use of real user analytical data — actual usage patterns, failure rates, and outcomes observed in production. This requires Brain-level tracking infrastructure (B2+ with session telemetry, outcome recording, and feedback loops) which is not yet built. Until that infrastructure exists, the above assessment dimensions serve as the best available proxy. When Brain tracking is available, this section should evolve into a data-driven assessment referencing actual metrics rather than probabilistic self-evaluation. See EDD-01 through EDD-05 in `plan/todo/03-testing-and-code-quality.md` for the evaluation-driven design gate system that will formalize this.
+### What goes wrong during assessment
 
-If any answer reveals a significant gap, note it as a finding and either fix it before proceeding or escalate to the Admiral with a recommendation.
-
-## Preconditions
-
-1. Confirm all phase tasks are complete in `plan/todo/*.md`.
-2. Confirm task PRs are merged into the phase slush branch.
-3. Confirm no unresolved merge conflicts remain.
+- **Completion bias.** The strongest pull is to say "yes" to all 9 questions and move on. If you find yourself answering "yes" to everything without evidence, slow down. Perfect scores are a red flag.
+- **Confusing "tests pass" with "it works."** Tests prove what they test. They don't prove what they don't test. Question #2 exists to catch this.
+- **Grounding drift.** A phase can produce technically correct work that nothing actually uses. Question #6 catches infrastructure built for hypothetical futures.
 
 ## Required Closeout Checks
 
-Run and pass all of the following for the phase as a whole set:
+Run and pass all of the following for the phase **as a whole set**:
 
-1. Full test suite (happy path and not-happy-path coverage remains valid).
+1. Full test suite (happy + unhappy path coverage).
 2. Full lint/format checks.
 3. Spellcheck for changed docs and user-facing text.
 4. Security gap review and hardening pass.
-5. CI pipeline status green for required workflows.
+5. CI pipeline green for required workflows.
 
-If any check fails:
+If any check fails: fix on the slush branch, re-run the failed check. If a fix introduces new failures, re-run the full set.
 
-1. Fix the issue on the phase slush branch.
-2. Re-run failed checks.
-3. Repeat until all checks pass or escalate to Admiral with recommended solutions.
+## Blocked Task Relocation
+
+For tasks that remain incomplete due to genuine blockers:
+
+1. Identify which blocker each task depends on and which phase resolves it.
+2. If the blocker is resolved in a **later** phase → relocate the task:
+   - Add it to the appropriate later phase's `plan/todo/*.md`, near where its blocker is resolved.
+   - Mark it with a deferral note and cross-reference in the current phase's TODO.
+3. Do NOT relocate tasks whose blockers are from the active or previous phases — these are genuine incomplete work and must remain visible.
+
+## Gate Check
+
+**All must pass before stationary updates:**
+
+1. Every task accounted for — complete, deferred with documented blocker, or relocated.
+2. Linters pass on all changed files.
+3. Full test suite passes.
+4. CI pipeline green.
+
+If any gate fails, fix and re-check. Do not proceed to stationary updates with a failing gate.
+
+## Stationary Updates
+
+**Only after the gate check passes**, update standing documents to reflect current project state:
+
+1. **README.md** — badges, feature highlights, project status.
+2. **plan/index.md** — scores, gap descriptions, completion counts.
+3. **ROADMAP.md** — phase completion notes.
+4. **component_versions.json** — component versions and file lists.
+5. Any other standing documents claiming counts, percentages, or statuses that changed.
 
 ## Merge Flow
 
-1. Sync main first:
-   - `git checkout main`
-   - `git pull --ff-only`
-2. Checkout phase slush branch and rebase/merge latest main as policy requires.
-3. Resolve conflicts and re-run required closeout checks.
-4. Locate the existing slush→main PR (opened when the slush branch was created per `/next-todo` policy). If it does not exist, open one now.
-5. Update the slush→main PR body with closeout results (checks run, fixes applied, CI status).
-6. Ensure required CI checks are green.
-7. **Do NOT merge the slush→main PR.** Mark it as ready for Admiral review and notify the Admiral.
-   - Only an Admiral may approve and merge slush branches into `main`.
+1. Sync main: `git checkout main`, `git pull --ff-only`.
+2. Checkout slush branch and rebase/merge latest main.
+3. If conflicts arise, resolve and re-run closeout checks.
+4. Locate the existing slush→main PR (opened by `/next-todo` when the slush branch was created). If missing, open one now.
+5. Update the PR body with closeout results: checks run, fixes applied, CI status, completion assessment summary.
+6. Ensure CI is green.
+7. **Do NOT merge.** Mark ready for Admiral review.
 
 ## TODO Updates
 
 Before stationary updates:
 
 1. Update phase/task statuses in `plan/todo/*.md`.
-2. Add concise closeout notes: checks run, outcomes, hardening performed, and merge result.
-3. If closeout blocked, record blocked state and Admiral escalation note.
+2. Add concise closeout notes: checks run, outcomes, hardening performed.
+3. If blocked, record blocked state and escalation note.
 
-## Blocked Task Relocation
+## What goes wrong during closeout
 
-After TODO updates, for any tasks that remain incomplete due to genuine blockers:
+- **Tests pass locally but CI fails.** Environment differences. Check CI logs, fix the environment-specific issue, don't disable the CI check.
+- **Spellcheck finds false positives.** Technical terms, acronyms, project-specific names. Add them to the spellcheck dictionary rather than ignoring the check.
+- **Stationary updates conflict with ongoing work.** If another branch has updated `plan/index.md` or `README.md`, merge main into slush and resolve. Re-run gate check after resolution.
+- **Blocked tasks have ambiguous blockers.** You can't tell if the blocker is this phase or a future phase. Leave it in the current phase — visibility is more important than tidiness. Note the ambiguity.
+- **Phase is "complete" but the Completion Assessment reveals gaps.** This is the assessment working as intended. Fix what you can. For gaps that require significant new work, note them as findings in the Output Contract and let the Admiral decide whether to defer or extend the phase.
 
-1. Identify which blocker each task depends on and which phase resolves that blocker.
-2. If the blocker is resolved by work in a **later** phase (not the active or any previous phase), relocate the task:
-   - Add the task to the appropriate later phase's `plan/todo/*.md` file, near where its blocker is resolved.
-   - In the current phase's TODO, mark the task with a deferral note and cross-reference to the destination file.
-3. Do NOT relocate tasks whose blockers are from the active or previous phases — these are genuine incomplete work and should remain visible as such.
+## Output Contract
 
-## Gate Check
+```
+CONTINUITY: [FRESH START | CLOSEOUT RESUMING: <details>]
 
-**All of the following must pass before proceeding to stationary updates:**
+COMPLETION ASSESSMENT:
+1. Completed as designed: [answer with evidence]
+2. Tests prove it works: [answer with evidence]
+3. Useful: [answer with evidence]
+4. Capable: [answer with evidence]
+5. Robust: [answer with evidence]
+6. Grounded: [answer with evidence]
+7. Simple: [answer with evidence]
+8. Can see it working: [answer with evidence]
+9. Could someone else confirm: [answer with evidence]
 
-1. All tasks accounted for — every item is either complete, deferred with documented blocker, or relocated to a later phase.
-2. Linters pass on all changed files.
-3. Full test suite passes.
-4. CI pipeline is green.
-
-If any gate fails, fix and re-check before continuing.
-
-## Stationary Updates
-
-**Only after the gate check passes**, update standing documents ("stationaries") to reflect the current state of the project:
-
-1. **README.md** — update badges, feature highlights, project status, or any sections that reference capabilities added in this phase.
-2. **plan/index.md** — update scores, gap descriptions, or completion counts if they are stale relative to work completed.
-3. **ROADMAP.md** — add phase completion notes if applicable.
-4. **component_versions.json** — update component versions and file lists to include new artifacts.
-5. Any other standing documents that claim specific counts, percentages, or statuses that have changed.
-
-After stationary updates, push and request Admiral review of the slush→main PR one final time.
-
-## Output Contract (always include)
-
-1. **Completion assessment** — honest answers to all 6 questions (useful, capable, robust, grounded, simple, as-designed).
-2. Phase and slush branch targeted.
-3. Preconditions status.
-4. Closeout checks run and results (tests, lint, spellcheck, security, CI).
-5. Fixes applied during closeout.
-6. TODO updates made.
-7. Blocked tasks relocated (which tasks, to which phase, why).
-8. Gate check results (all tasks accounted for, linters, tests, CI).
-9. Stationary updates applied (README, index, ROADMAP, component_versions, etc.).
-10. PR/merge status into `main`.
-11. Any Admiral escalation details and recommended solutions.
+PHASE: <NN> — <name>
+SLUSH BRANCH: <branch name>
+PRECONDITIONS: [all met | gaps found]
+CLOSEOUT CHECKS: [tests, lint, spellcheck, security, CI — pass/fail each]
+FIXES APPLIED: [what was fixed during closeout]
+TODO UPDATES: [what was marked, annotated, relocated]
+BLOCKED TASKS: [which tasks, relocated to which phase, why]
+GATE CHECK: [all tasks accounted, linters, tests, CI — pass/fail each]
+STATIONARY UPDATES: [which docs updated]
+PR STATUS: [PR URL, CI status, marked for Admiral review]
+ESCALATIONS: [if any — what, why, recommendation]
+```
 
 ## Non-Goals
 
 - Do not create new TODO items.
-- Do not modify `aiStrat/`.
-- Do not bypass required CI or quality gates.
+- Do not bypass CI or quality gates.
+- Do not merge slush→main. Admiral approval required.

--- a/.claude/commands/repeat.md
+++ b/.claude/commands/repeat.md
@@ -1,0 +1,265 @@
+# /repeat
+
+Run a task in an event-driven loop, re-triggering when specified criteria are met rather than on a timer.
+
+> **Prerequisites:** See [`_primer.md`](_primer.md) for operational definitions (Admiral, Work Hierarchy, Decision Authority, Recovery Ladder, etc.)
+
+## Mission
+
+Execute a task chain repeatedly. Each iteration runs until a condition (repeatFlag) is satisfied, then executes transition logic (exitStrategy), then starts again. The loop is event-driven — for timer-based repetition, use `/loop`.
+
+## Entry State
+
+- A valid `/repeat` invocation with all required parameters.
+- Git state is recoverable (branches, PRs, TODOs) for session continuity.
+
+## Exit State
+
+- `endRepeat` condition satisfied, OR user interruption, OR unrecoverable error.
+- Current iteration's work is committed and checkpoint is produced.
+- Git working tree is clean.
+
+## Syntax
+
+```
+/repeat {task: `<commands>`,
+         exitStrategy: "<transition logic>",
+         repeatFlag: <condition>,
+         conditions: [...],
+         endRepeat: "<termination condition>"}
+```
+
+## Parameters
+
+### Required
+
+- **task**: The command chain to execute each iteration. See **Task Syntax** below.
+- **repeatFlag**: The condition that signals iteration completion.
+  - Slash command reference (e.g., `/phase-closeout`): fires when that command completes successfully.
+  - Plain-language condition: evaluated honestly after each major step.
+- **exitStrategy**: What to do between iterations — branch creation, state reset, context advancement. See **Exit Strategy Contract** below.
+
+### Optional
+
+- **conditions**: Standing rules enforced throughout every iteration. See **Condition Categories** below. Violation is immediate and unrecoverable — no Recovery Ladder.
+- **endRepeat**: Termination condition that ends the loop gracefully. Evaluated after each major step alongside repeatFlag. When satisfied, the current step completes, then the loop exits without starting a new iteration.
+
+## Task Syntax
+
+Three composition patterns, freely combinable:
+
+### 1. Slash command chaining
+
+Semicolon-separated, sequential, left to right. Each must complete before the next begins.
+
+```
+task: `/next-todo; /simplify; /phase-closeout`
+```
+
+### 2. Sub-command arguments
+
+Flags and directive arrays that scope a slash command's behavior for this invocation only.
+
+```
+/plan --auto-approve ["Build in correct order", "Use slush branch conventions"]
+```
+
+- **Flags** (`--flag-name`): Boolean on/off switches. Unrecognized flags are logged as warnings and ignored.
+- **Directive arrays** (`["...", "..."]`): Plain-language instructions appended to the sub-command's mission for this invocation. Do not persist across iterations or carry to subsequent commands.
+
+Positional: flags and directives attach to the slash command immediately preceding them.
+
+### 3. Inline prose directives
+
+Double-quoted strings between commands. Executed as standalone evaluation steps.
+
+```
+task: `/plan; "Verify the phase objective is genuinely met"; /phase-closeout`
+```
+
+- Must be evaluated honestly — not rubber-stamped.
+- Treated as verification gates: if fail, do not proceed. Assess what needs to change.
+- Logged with pass/fail, evidence, and reasoning in the Output Contract.
+
+## Condition Categories
+
+### Constraints
+
+Absolute restrictions. Violations stop the loop immediately.
+
+```
+"Do not write to aiStrat/"
+"No compound commands in bash (no &&)"
+```
+
+### Permissions
+
+Explicit grants that override default caution — elevating certain actions from Propose to Autonomous.
+
+```
+"Full read/write access in /technomancy-codex"
+"May merge task PRs without human approval"
+```
+
+Permissions cannot override safety constraints or Standing Orders.
+
+### Behavioral directives
+
+Approach and priority guidance. Lowest precedence — they shape judgment, not mandate.
+
+```
+"Prefer small commits over large ones"
+"Use existing patterns from the codebase"
+```
+
+### When conditions conflict
+
+Highest to lowest precedence: Standing Orders (safety) → constraints → sub-command contracts → permissions → behavioral directives. If unresolvable, escalate.
+
+## Exit Strategy Contract
+
+The exitStrategy must:
+
+1. **Execute fully** between every iteration. Skipping is a hard violation (unless `endRepeat` terminates the loop).
+2. **Leave a clean entry state** for the next iteration:
+   - Branches from the completed iteration are merged or cleaned up.
+   - Working tree is clean.
+   - Next iteration's starting branch exists and is checked out.
+3. **Follow branch policy** from `/next-todo` if creating branches.
+
+If the exitStrategy fails: follow the Recovery Ladder. Do not start the next iteration with a dirty transition.
+
+## endRepeat Evaluation
+
+### Plain-language conditions
+
+Evaluated honestly using available information. "All phases complete" → check `plan/todo/*.md` and `plan/ROADMAP.md`. "User says stop" → only by explicit interruption.
+
+### Token/context conditions
+
+For conditions like "less than 100000 tokens remain":
+- Use conservative estimates — err toward graceful termination.
+- Message compression is evidence that context is constrained.
+- If `token_budget_tracker` reports ≥80% utilization, context-limit conditions are likely satisfied.
+
+### Interaction with repeatFlag
+
+- If `endRepeat` fires before repeatFlag: complete the current step, then exit. Do not force the repeatFlag.
+- If both fire simultaneously: execute exitStrategy only if the next iteration is viable.
+- If neither fires and the task chain completes: the repeatFlag should have fired but didn't. Investigate — did a sub-command fail silently?
+
+## Iteration State
+
+### Carries forward
+
+- Iteration counter (N).
+- `conditions` (immutable for the loop's lifetime).
+- `endRepeat` (re-evaluated fresh each iteration).
+- Git state (branches, commits, PRs).
+
+### Resets each iteration
+
+- Directive arrays and inline prose results.
+- Sub-command internal state (each runs its own Session Continuity Protocol).
+- Recovery Ladder position.
+
+## Context Window Management
+
+Long-running loops consume context. Three defenses:
+
+1. **No iteration should consume more than 40% of remaining budget.** If an iteration approaches this, complete the current step, checkpoint, and evaluate whether to terminate.
+2. **Rely on git state over conversation memory.** When context compresses, branches, commits, and PR state are the authoritative record.
+3. **Preemptive termination.** If the current iteration can complete but the next one likely cannot, terminate gracefully: `REPEAT preemptive termination: context window insufficient for another full iteration`.
+
+## Session Continuity
+
+If interrupted mid-loop:
+
+1. Sub-commands have their own continuity protocols (e.g., `/next-todo` Session Continuity).
+2. Detect loop state from git: branches (`slush/`, `task/`), PR state (`gh pr list`), TODO completion in `plan/todo/*.md`, commit messages indicating iteration boundaries.
+3. Resume from the interrupted point. Reconstruct iteration counter from completed work.
+4. Report: `REPEAT resuming at iteration N (detected in-progress state from prior session)`.
+5. If original parameters are lost (context gone), ask the Admiral to re-issue the command.
+
+## Execution Algorithm
+
+1. **Parse and validate.** All required parameters present. Parse conditions and endRepeat if provided.
+2. **Log**: `REPEAT iteration N starting`.
+3. **Check conditions** before each major step. Violation → immediate escalation.
+4. **Execute the task chain** sequentially. Pass flags and directive arrays to sub-commands. Evaluate inline directives honestly.
+5. **After each major step**, evaluate repeatFlag and endRepeat.
+6. **On repeatFlag firing**: log it, execute exitStrategy per contract, log completion, start next iteration.
+7. **On endRepeat firing**: complete current step, log `REPEAT terminated after iteration N: <reason>`, exit.
+8. **On failure**: follow Recovery Ladder. If unrecoverable, escalate with iteration number, what failed, and whether it's safe to resume.
+
+## What goes wrong during repeat loops
+
+- **Exit strategy leaves dirty state.** Next iteration starts on the wrong branch or with uncommitted changes. The exit strategy contract exists to prevent this — if it fails, escalate rather than pushing forward.
+- **repeatFlag never fires.** The task chain completes but the condition isn't met. Usually means a sub-command failed silently or the flag condition doesn't match what the task chain actually produces. Investigate before retrying.
+- **Conditions conflict with sub-command behavior.** A condition says "no compound commands" but a sub-command tries to run one. The condition wins — the sub-command hits a hook block. This is expected behavior, not a bug.
+- **Context window runs out mid-iteration.** The 40% rule and preemptive termination exist for this. If you're past 80% budget and mid-iteration, finish the current major step, checkpoint, and terminate.
+- **Iteration drift.** Each iteration should produce roughly equivalent work (one phase, one task cycle). If iterations are getting smaller or shallower, it's likely context exhaustion or completion bias. Terminate and let a fresh session continue.
+
+## Output Contract (per iteration)
+
+```
+REPEAT ITERATION N
+STATUS: [Complete | Blocked | Terminated]
+CONTINUITY: [FRESH START | RESUMING at N]
+
+CONDITIONS: [all passing | violation details]
+
+TASK EXECUTION:
+1. [command/directive]: [result summary]
+2. [command/directive]: [result summary]
+...
+
+REPEATFLAG: [condition] — [fired | not fired] — [evidence]
+ENDREPEAT: [condition] — [fired | not fired | N/A] — [evidence]
+EXIT STRATEGY: [executed — what was done | skipped — endRepeat fired]
+
+NEXT: [iteration N+1 | termination reason]
+ROUTING SUGGESTIONS: [work discovered outside loop scope]
+```
+
+## Examples
+
+### Basic
+
+```
+/repeat {task: `/next-todo; /simplify; /phase-closeout`,
+         exitStrategy: "create a new slush branch off main for the next phase",
+         repeatFlag: /phase-closeout}
+```
+
+### Full
+
+```
+/repeat {task: `/next-todo; /plan --auto-approve ["Continue plan/todo/* work",
+              "Build in correct order", "Use slush branch conventions",
+              "Continue until the Phase is fully realized"];
+              "Genuinely prove the phase is complete — not just tests and checklists";
+              /simplify; /security-review; /phase-closeout`,
+         exitStrategy: "create a new slush branch off the active slush branch and begin the next phase",
+         repeatFlag: /phase-closeout,
+         conditions: ["No compound commands in bash (no &&)",
+                      "Full read/write access in /technomancy-codex",
+                      "Do not write to aiStrat/"],
+         endRepeat: "When the phase is complete and less than 100000 tokens remain"}
+```
+
+### Minimal with endRepeat
+
+```
+/repeat {task: `/next-todo`,
+         exitStrategy: "commit progress and check out the next task branch",
+         repeatFlag: "current task's PR is merged into the slush branch",
+         endRepeat: "all tasks in the active phase are complete"}
+```
+
+## Non-Goals
+
+- Do not invent new TODO items.
+- Do not merge slush to main without Admiral approval.
+- Do not run on a timer — use `/loop`.
+- Do not use for one-shot tasks — just run the commands directly.


### PR DESCRIPTION
## Summary

- Add `_primer.md` as shared operational glossary bridging abstract Admiral spec → concrete command execution
- Rewrite `/next-todo`, `/phase-closeout` as lean Layer 3 (Task Context) documents with entry/exit states, Session Continuity, structured Output Contracts, and command-specific failure modes
- Add `/repeat` command with conditions, endRepeat, sub-command arguments, inline prose directives, and context window management
- Fix `/phase-closeout` Output Contract (was referencing 6 questions, there are 9 evaluation dimensions)
- Cut Layer 1 duplication — commands no longer restate Standing Orders, Recovery Ladder, or generic escalation format

## Test plan

- [ ] Verify `_primer.md` renders correctly and all cross-references are valid
- [ ] Verify `/next-todo` Session Continuity Protocol still matches git branch conventions
- [ ] Verify `/phase-closeout` 9 evaluation dimensions match Output Contract template
- [ ] Verify `/repeat` examples parse correctly when invoked
- [ ] Confirm no Layer 1 content was lost (it lives in Standing Orders, not commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)