### PR TITLE
T-15: Property-based testing for RingBuffer

### DIFF
--- a/control-plane/package-lock.json
+++ b/control-plane/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@types/node": "^25.5.0",
+        "fast-check": "^4.6.0",
         "typescript": "^5.9.3"
       }
     },
@@ -186,6 +187,44 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/control-plane/package.json
+++ b/control-plane/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@types/node": "^25.5.0",
+    "fast-check": "^4.6.0",
     "typescript": "^5.9.3"
   }
 }

--- a/control-plane/src/ring-buffer.property.test.ts
+++ b/control-plane/src/ring-buffer.property.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import fc from "fast-check";
+import { RingBuffer } from "./ring-buffer";
+
+describe("RingBuffer property-based tests", () => {
+  // Invariant 1: size never exceeds capacity
+  it("size never exceeds capacity after N pushes", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 1000 }),
+        fc.array(fc.integer(), { minLength: 0, maxLength: 2000 }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) {
+            buf.push(item);
+            assert.ok(
+              buf.size <= capacity,
+              `size ${buf.size} exceeded capacity ${capacity}`,
+            );
+          }
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 2: toArray returns items in insertion order
+  it("toArray returns items in insertion order", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }),
+        fc.array(fc.integer(), { minLength: 0, maxLength: 500 }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) {
+            buf.push(item);
+          }
+          const arr = buf.toArray();
+
+          // The array should contain the last min(items.length, capacity) items
+          const expected = items.slice(-capacity);
+          assert.deepEqual(arr, expected);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 3: correct element count after N pushes
+  it("size equals min(pushCount, capacity)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 500 }),
+        fc.integer({ min: 0, max: 2000 }),
+        (capacity, pushCount) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (let i = 0; i < pushCount; i++) {
+            buf.push(i);
+          }
+          assert.equal(buf.size, Math.min(pushCount, capacity));
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 4: evicted elements are the oldest
+  it("evictedCount equals max(0, pushCount - capacity)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 500 }),
+        fc.integer({ min: 0, max: 2000 }),
+        (capacity, pushCount) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (let i = 0; i < pushCount; i++) {
+            buf.push(i);
+          }
+          assert.equal(buf.evictedCount, Math.max(0, pushCount - capacity));
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 5: get(i) matches toArray()[i] for all valid indices
+  it("get(i) is consistent with toArray()[i]", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }),
+        fc.array(fc.integer(), { minLength: 1, maxLength: 300 }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) {
+            buf.push(item);
+          }
+          const arr = buf.toArray();
+          for (let i = 0; i < arr.length; i++) {
+            assert.equal(
+              buf.get(i),
+              arr[i],
+              `get(${i}) mismatch: ${buf.get(i)} vs ${arr[i]}`,
+            );
+          }
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 6: iterator yields same sequence as toArray
+  it("iterator yields same sequence as toArray", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }),
+        fc.array(fc.integer(), { minLength: 0, maxLength: 300 }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) {
+            buf.push(item);
+          }
+          const fromArray = buf.toArray();
+          const fromIter = [...buf];
+          assert.deepEqual(fromIter, fromArray);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 7: clear resets all state
+  it("clear resets size, evictedCount, and contents", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }),
+        fc.array(fc.integer(), { minLength: 1, maxLength: 200 }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) {
+            buf.push(item);
+          }
+          buf.clear();
+          assert.equal(buf.size, 0);
+          assert.equal(buf.evictedCount, 0);
+          assert.deepEqual(buf.toArray(), []);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 8: buffer is reusable after clear
+  it("buffer works correctly after clear and reuse", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 50 }),
+        fc.array(fc.integer(), { minLength: 1, maxLength: 100 }),
+        fc.array(fc.integer(), { minLength: 1, maxLength: 100 }),
+        (capacity, firstBatch, secondBatch) => {
+          const buf = new RingBuffer<number>(capacity);
+
+          for (const item of firstBatch) buf.push(item);
+          buf.clear();
+
+          for (const item of secondBatch) buf.push(item);
+
+          assert.equal(buf.size, Math.min(secondBatch.length, capacity));
+          assert.deepEqual(buf.toArray(), secondBatch.slice(-capacity));
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 9: filter preserves ordering and is a subset of toArray
+  it("filter results are a subset of toArray in order", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 50 }),
+        fc.array(fc.integer({ min: -100, max: 100 }), {
+          minLength: 1,
+          maxLength: 200,
+        }),
+        (capacity, items) => {
+          const buf = new RingBuffer<number>(capacity);
+          for (const item of items) buf.push(item);
+
+          const predicate = (n: number) => n > 0;
+          const filtered = buf.filter(predicate);
+          const allItems = buf.toArray();
+          const expected = allItems.filter(predicate);
+
+          assert.deepEqual(filtered, expected);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
+  // Invariant 10: capacity of 1 always holds only the last item
+  it("capacity-1 buffer always holds only the last pushed item", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer(), { minLength: 1, maxLength: 500 }),
+        (items) => {
+          const buf = new RingBuffer<number>(1);
+          for (const item of items) buf.push(item);
+
+          assert.equal(buf.size, 1);
+          assert.equal(buf.get(0), items[items.length - 1]);
+          assert.equal(buf.evictedCount, items.length - 1);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+});

--- a/control-plane/tsconfig.json
+++ b/control-plane/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": ".",

--- a/plan/todo/03-testing-and-code-quality.md
+++ b/plan/todo/03-testing-and-code-quality.md
@@ -29,7 +29,7 @@
 
 ## Advanced Testing Techniques
 
-- [ ] **T-15: Property-based testing for RingBuffer** — *Deferred to Phase 2 (requires fast-check npm dependency setup).* — Use fast-check to verify RingBuffer invariants: size never exceeds capacity, toArray returns insertion order, correct element count after N pushes, evicted elements are oldest. Done when property tests pass with 1000+ generated test cases.
+- [x] **T-15: Property-based testing for RingBuffer** — *Completed in Phase 9.* — Added fast-check dependency and 10 property-based tests: size bounds, insertion order, element count, eviction count, get/toArray consistency, iterator/toArray consistency, clear reset, reuse after clear, filter ordering, capacity-1 behavior. 10,000 generated test cases (1000 per property), all passing. Updated tsconfig moduleResolution to node16.
 - [ ] **T-16: Mutation testing setup** — *Deferred to Phase 2 (requires Stryker setup, pilot scope).* — Configure Stryker for mutation testing. Start with RingBuffer and EventStream as pilot modules. Done when mutation score >=80% for pilot modules.
 - [x] **T-17: Test for `standing_orders.sh` rendering** — Verify all 16 Standing Orders render correctly from source files. Test missing SO files for graceful degradation. Done when output format matches expected template.
 - [x] **T-18: Test for `injection_detect.sh`** — Verify all 5 quarantine layers with comprehensive attack corpus (>=10 attack vectors per layer). Done when false positive rate < 1% on benign corpus, all attack items correctly flagged.


### PR DESCRIPTION
## Summary

- Added fast-check devDependency for property-based testing
- Created 10 property-based tests with 1000 generated test cases each
- Updated tsconfig moduleResolution to node16 for fast-check compatibility
- All 28 ring-buffer tests pass (10 property + 18 existing)

## Test plan

- [x] All 10 property tests pass locally (10,000 generated cases)
- [x] Existing 18 unit tests still pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)