### PR TITLE
feat(sec-15): Leash Cedar policy generation spec

### DIFF
--- a/admiral/docs/leash-integration-spec.md
+++ b/admiral/docs/leash-integration-spec.md
@@ -1,0 +1,182 @@
+# Leash Cedar Policy Generation Spec (SEC-15)
+
+> Design mapping from Admiral's Decision Authority Tiers to Cedar policy language for StrongDM Leash kernel-level enforcement.
+
+## Overview
+
+StrongDM Leash provides kernel-level enforcement with Cedar policies. Admiral's competitive strategy is **integration, not competition**: Admiral generates Cedar policies from agent tier assignments, making Leash an enforcement backend rather than a competitor.
+
+## Authority Tier to Cedar Mapping
+
+Admiral defines 4 authority tiers (from highest to lowest privilege):
+
+| Admiral Tier | Behavior | Cedar Effect |
+|---|---|---|
+| **Enforced** | System-level rules, no agent override | `forbid` — unconditional deny regardless of agent role |
+| **Autonomous** | Agent executes and logs | `permit` — allow with logging condition |
+| **Propose** | Agent drafts proposal, awaits approval | `forbid` with approval exception — deny unless `context.approval_status == "approved"` |
+| **Escalate** | Agent halts, escalates to Admiral | `forbid` — deny unconditionally at agent level |
+
+### Tier Mapping Details
+
+#### Enforced (System Constraints)
+
+Standing Orders (SO-01 through SO-17) are system-level constraints that no agent can override. These map to unconditional `forbid` policies.
+
+```cedar
+// SO-10: Prohibitions — never store PII in Brain
+forbid (
+  principal,
+  action == Action::"brain_write",
+  resource
+)
+when { resource.contains_pii == true };
+```
+
+#### Autonomous
+
+Actions an agent is explicitly authorized to perform. Map to `permit` with mandatory logging.
+
+```cedar
+// Implementer agent: autonomous code writing
+permit (
+  principal == Agent::"implementer-1",
+  action == Action::"write_code",
+  resource
+)
+when { resource in Scope::"assigned_project" };
+```
+
+#### Propose
+
+Actions requiring written proposal before execution. Map to `forbid` with an approval-gate exception.
+
+```cedar
+// Implementer agent: config changes require proposal
+forbid (
+  principal == Agent::"implementer-1",
+  action == Action::"modify_config",
+  resource
+)
+unless { context.approval_status == "approved" };
+```
+
+#### Escalate
+
+Actions that require immediate halt and Admiral intervention. Map to unconditional `forbid` at the agent level — only Admiral can permit.
+
+```cedar
+// Implementer agent: cannot delete data
+forbid (
+  principal == Agent::"implementer-1",
+  action == Action::"delete_data",
+  resource
+);
+```
+
+## Entity Model
+
+Cedar requires a typed entity model. Admiral maps as follows:
+
+```
+namespace Admiral {
+  entity Agent;
+  entity Scope;
+  entity Resource;
+
+  action "read_files" appliesTo { principal: Agent, resource: Resource };
+  action "write_code" appliesTo { principal: Agent, resource: Resource };
+  action "modify_config" appliesTo { principal: Agent, resource: Resource };
+  action "delete_data" appliesTo { principal: Agent, resource: Resource };
+  action "modify_permissions" appliesTo { principal: Agent, resource: Resource };
+  action "brain_write" appliesTo { principal: Agent, resource: Resource };
+  action "brain_read" appliesTo { principal: Agent, resource: Resource };
+  action "tool_invoke" appliesTo { principal: Agent, resource: Resource };
+  action "delegate_task" appliesTo { principal: Agent, resource: Resource };
+  action "escalate" appliesTo { principal: Agent, resource: Resource };
+}
+```
+
+## Policy Generation Algorithm
+
+Given an agent definition JSON with authority tiers:
+
+```
+Input:  agent-definition.v1.json (agent_id, authority.{autonomous, propose, escalate})
+Output: <agent_id>.cedar (Cedar policy file)
+```
+
+### Steps
+
+1. **Parse** the agent definition's `authority` object.
+2. **For each autonomous action**: generate a `permit` policy with the agent as principal and the action name mapped to a Cedar action.
+3. **For each propose action**: generate a `forbid` policy with an `unless { context.approval_status == "approved" }` clause.
+4. **For each escalate action**: generate an unconditional `forbid` policy.
+5. **Append Standing Order policies**: universal `forbid` rules that apply to all agents (generated once, shared).
+6. **Write** the policy set to `<agent_id>.cedar`.
+
+### Policy Generation Triggers
+
+Cedar policies should be regenerated when:
+- An agent definition is created or modified
+- Authority tier assignments change
+- Standing Orders are updated
+- Fleet registry is updated
+
+In CI, policy generation runs as a validation step (policies are generated and validated but not deployed — deployment is Leash's responsibility).
+
+## Deployment Scenarios
+
+### Leash-Present Deployment
+
+When StrongDM Leash is available:
+1. Admiral generates Cedar policies from agent definitions.
+2. Policies are pushed to Leash via its policy API.
+3. Leash enforces at kernel level — every tool invocation, file access, and API call is checked.
+4. Admiral's `privilege_check.sh` hook becomes advisory (belt-and-suspenders).
+5. Leash enforcement is authoritative; Admiral enforcement is defense-in-depth.
+
+```
+Agent → Tool Call → Leash Cedar Check (kernel) → Admiral Hook Check (app) → Execute
+```
+
+### Leash-Absent Deployment
+
+When Leash is not available (default — current state):
+1. Cedar policies are generated but not enforced externally.
+2. Admiral's `privilege_check.sh` hook is the primary enforcer.
+3. `PrivilegeEnforcer` (SEC-04) validates authority tiers at runtime.
+4. Generated Cedar policies serve as documentation of intended enforcement.
+5. Audit trail tracks what Leash *would have* enforced.
+
+```
+Agent → Tool Call → Admiral Hook Check (app) → PrivilegeEnforcer Check → Execute
+```
+
+### Migration Path
+
+1. **Phase 1 (current):** Generate and validate Cedar policies. No external enforcement.
+2. **Phase 2:** Deploy Leash in audit-only mode — log what it would block.
+3. **Phase 3:** Enable Leash enforcement with Admiral as fallback.
+4. **Phase 4:** Leash is authoritative; Admiral hooks are defense-in-depth only.
+
+## Validation
+
+Cedar policies can be validated with the Cedar CLI:
+```bash
+cedar validate --schema admiral-schema.cedarschema --policies <agent>.cedar
+```
+
+Policy correctness tests:
+- Every autonomous action has a corresponding `permit`
+- Every propose action has a `forbid` with approval gate
+- Every escalate action has an unconditional `forbid`
+- Standing Order policies are present for all SO-* rules
+- No `permit` exists without a corresponding agent definition
+
+## Security Considerations
+
+- **Policy source of truth:** Agent definitions in `fleet/definitions/` are the source. Cedar policies are derived — never edited directly.
+- **No Cedar-to-Admiral backflow:** Leash cannot modify Admiral's authority assignments. The flow is unidirectional (ATK-0003 defense extends to Cedar: no agent can modify its own Cedar policies).
+- **Stale policy detection:** If an agent definition changes but Cedar policies are not regenerated, a drift detector should flag the discrepancy.
+- **Least privilege default:** Unclassified actions default to `escalate` (deny) in both Admiral and Cedar.

--- a/admiral/security/cedar-generator/examples/implementer-1.cedar
+++ b/admiral/security/cedar-generator/examples/implementer-1.cedar
@@ -1,0 +1,59 @@
+// Cedar Policy: implementer-1
+// Generated from agent-definition: implementer-1 v1.0.0
+// Role: implementer
+// Generated at: 2026-03-28T00:00:00Z
+//
+// Authority tiers:
+//   autonomous: write_code, run_tests, read_files
+//   propose:    modify_config, add_dependency
+//   escalate:   delete_data, modify_permissions
+
+// --- Autonomous tier (permit) ---
+
+permit (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"write_code",
+  resource
+);
+
+permit (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"run_tests",
+  resource
+);
+
+permit (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"read_files",
+  resource
+);
+
+// --- Propose tier (forbid unless approved) ---
+
+forbid (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"modify_config",
+  resource
+)
+unless { context.approval_status == "approved" };
+
+forbid (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"add_dependency",
+  resource
+)
+unless { context.approval_status == "approved" };
+
+// --- Escalate tier (unconditional forbid) ---
+
+forbid (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"delete_data",
+  resource
+);
+
+forbid (
+  principal == Admiral::Agent::"implementer-1",
+  action == Admiral::Action::"modify_permissions",
+  resource
+);

--- a/admiral/security/cedar-generator/examples/security-agent.cedar
+++ b/admiral/security/cedar-generator/examples/security-agent.cedar
@@ -1,0 +1,65 @@
+// Cedar Policy: security-agent
+// Generated from agent-definition: security-agent v1.0.0
+// Role: security
+// Generated at: 2026-03-28T00:00:00Z
+//
+// Authority tiers:
+//   autonomous: scan_vulnerabilities, read_files, modify_permissions, audit_review
+//   propose:    quarantine_entry, security_exception
+//   escalate:   delete_data, standing_order_override
+
+// --- Autonomous tier (permit) ---
+
+permit (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"scan_vulnerabilities",
+  resource
+);
+
+permit (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"read_files",
+  resource
+);
+
+permit (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"modify_permissions",
+  resource
+);
+
+permit (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"audit_review",
+  resource
+);
+
+// --- Propose tier (forbid unless approved) ---
+
+forbid (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"quarantine_entry",
+  resource
+)
+unless { context.approval_status == "approved" };
+
+forbid (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"security_exception",
+  resource
+)
+unless { context.approval_status == "approved" };
+
+// --- Escalate tier (unconditional forbid) ---
+
+forbid (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"delete_data",
+  resource
+);
+
+forbid (
+  principal == Admiral::Agent::"security-agent",
+  action == Admiral::Action::"standing_order_override",
+  resource
+);

--- a/admiral/security/cedar-generator/examples/standing-orders.cedar
+++ b/admiral/security/cedar-generator/examples/standing-orders.cedar
@@ -1,0 +1,58 @@
+// Cedar Policy: Standing Orders (Universal)
+// These policies apply to ALL agents unconditionally.
+// Generated from Standing Orders SO-01 through SO-17.
+// Generated at: 2026-03-28T00:00:00Z
+
+// --- SO-10: Prohibitions ---
+
+// No agent may store PII in Brain entries
+forbid (
+  principal,
+  action == Admiral::Action::"brain_write",
+  resource
+)
+when { resource.contains_pii == true };
+
+// No agent may approve its own work
+forbid (
+  principal,
+  action == Admiral::Action::"approve_work",
+  resource
+)
+when { resource.author == principal };
+
+// --- SO-05: Decision Authority ---
+
+// No agent may modify its own authority tier
+forbid (
+  principal,
+  action == Admiral::Action::"modify_authority",
+  resource
+)
+when { resource.target_agent == principal };
+
+// --- SO-12: Zero Trust ---
+
+// No agent may bypass quarantine pipeline
+forbid (
+  principal,
+  action == Admiral::Action::"bypass_quarantine",
+  resource
+);
+
+// No agent may disable audit logging
+forbid (
+  principal,
+  action == Admiral::Action::"disable_audit",
+  resource
+);
+
+// --- SO-09: Security Protocol ---
+
+// No agent may access resources above their clearance level
+forbid (
+  principal,
+  action == Admiral::Action::"access_resource",
+  resource
+)
+when { resource.sensitivity_level > principal.clearance_level };

--- a/admiral/tests/test_leash_cedar_spec.sh
+++ b/admiral/tests/test_leash_cedar_spec.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Admiral Framework — Leash Cedar Integration Spec Tests (SEC-15)
+# Validates the spec document and example Cedar policies.
+# Exit code: 0 = all pass, 1 = failures
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/assert.sh"
+
+SPEC_FILE="$PROJECT_DIR/admiral/docs/leash-integration-spec.md"
+EXAMPLES_DIR="$PROJECT_DIR/admiral/security/cedar-generator/examples"
+
+echo "=== Leash Cedar Integration Spec Tests (SEC-15) ==="
+echo ""
+
+# ─── File existence ────────────────────────────────────────────────
+
+echo "--- File existence ---"
+
+assert_file_exists "Spec document exists" "$SPEC_FILE"
+assert_file_exists "Implementer example exists" "$EXAMPLES_DIR/implementer-1.cedar"
+assert_file_exists "Security agent example exists" "$EXAMPLES_DIR/security-agent.cedar"
+assert_file_exists "Standing orders example exists" "$EXAMPLES_DIR/standing-orders.cedar"
+
+# ─── Spec content coverage ────────────────────────────────────────
+
+echo ""
+echo "--- Spec covers all 4 authority tiers ---"
+
+TIERS=("Enforced" "Autonomous" "Propose" "Escalate")
+
+for tier in "${TIERS[@]}"; do
+  if grep -qi "$tier" "$SPEC_FILE"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] Spec covers tier: $tier"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] Spec missing tier: $tier\n"
+    echo "  [FAIL] Spec missing tier: $tier"
+  fi
+done
+
+echo ""
+echo "--- Spec covers deployment scenarios ---"
+
+SCENARIOS=("Leash-Present" "Leash-Absent" "Migration")
+
+for scenario in "${SCENARIOS[@]}"; do
+  if grep -qi "$scenario" "$SPEC_FILE"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] Spec covers scenario: $scenario"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] Spec missing scenario: $scenario\n"
+    echo "  [FAIL] Spec missing scenario: $scenario"
+  fi
+done
+
+echo ""
+echo "--- Spec references key concepts ---"
+
+CONCEPTS=("Cedar" "permit" "forbid" "entity" "policy" "Standing Order" "ATK-0003" "approval")
+
+for concept in "${CONCEPTS[@]}"; do
+  if grep -q "$concept" "$SPEC_FILE"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] Spec references: $concept"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] Spec missing reference: $concept\n"
+    echo "  [FAIL] Spec missing reference: $concept"
+  fi
+done
+
+# ─── Example Cedar policy validation ──────────────────────────────
+
+echo ""
+echo "--- Cedar policy examples ---"
+
+for example in "$EXAMPLES_DIR"/*.cedar; do
+  filename=$(basename "$example")
+
+  # Check for permit/forbid statements
+  if grep -q "permit\|forbid" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename contains policy statements"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing policy statements\n"
+    echo "  [FAIL] $filename missing policy statements"
+  fi
+
+  # Check for principal/action/resource pattern
+  if grep -q "principal" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename uses principal"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing principal\n"
+    echo "  [FAIL] $filename missing principal"
+  fi
+
+  if grep -q "action" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename uses action"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing action\n"
+    echo "  [FAIL] $filename missing action"
+  fi
+done
+
+# ─── Agent example completeness ────────────────────────────────────
+
+echo ""
+echo "--- Agent example tier coverage ---"
+
+for example in "$EXAMPLES_DIR/implementer-1.cedar" "$EXAMPLES_DIR/security-agent.cedar"; do
+  filename=$(basename "$example")
+
+  if grep -q "permit" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename has autonomous (permit) policies"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing autonomous policies\n"
+    echo "  [FAIL] $filename missing autonomous policies"
+  fi
+
+  if grep -q "unless" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename has propose (forbid unless) policies"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing propose policies\n"
+    echo "  [FAIL] $filename missing propose policies"
+  fi
+
+  if grep -q "forbid" "$example"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] $filename has escalate (forbid) policies"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] $filename missing escalate policies\n"
+    echo "  [FAIL] $filename missing escalate policies"
+  fi
+done
+
+# ─── Standing orders example ──────────────────────────────────────
+
+echo ""
+echo "--- Standing orders Cedar coverage ---"
+
+SO_REFS=("SO-10" "SO-05" "SO-12" "SO-09")
+
+for so in "${SO_REFS[@]}"; do
+  if grep -q "$so" "$EXAMPLES_DIR/standing-orders.cedar"; then
+    PASS=$((PASS + 1))
+    echo "  [PASS] Standing orders example covers: $so"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+="  [FAIL] Standing orders example missing: $so\n"
+    echo "  [FAIL] Standing orders example missing: $so"
+  fi
+done
+
+# ─── Summary ──────────────────────────────────────────────────────
+
+print_results "Leash Cedar Integration Spec Tests"

--- a/plan/todo/07-security-and-robustness.md
+++ b/plan/todo/07-security-and-robustness.md
@@ -47,7 +47,7 @@ Defense in depth for the Admiral Framework: adversarial testing, injection defen
 
 ## Leash Integration
 
-- [ ] **SEC-15: Leash Cedar policy generation spec** — Design mapping from Admiral's Decision Authority Tiers (Autonomous/Propose/Escalate/Blocked) to Cedar policy language. Generate Cedar policies from agent tier assignments for StrongDM Leash kernel-level enforcement. Cover tier-to-Cedar mapping, policy generation triggers, Leash-present and Leash-absent deployment. Turns Leash from competitor into enforcement backend. Depends on SEC-04.
+- [x] **SEC-15: Leash Cedar policy generation spec** — *Completed in Phase 10.* — `admiral/docs/leash-integration-spec.md` maps all 4 authority tiers (Enforced/Autonomous/Propose/Escalate) to Cedar policy language. Entity model, policy generation algorithm, triggers, and 4-phase migration path. Covers Leash-present and Leash-absent deployment. 3 example Cedar policies (implementer-1, security-agent, standing-orders) in `admiral/security/cedar-generator/examples/`. 38-test validation suite.
 
 ## CI Security
 


### PR DESCRIPTION
## Summary
- Add `admiral/docs/leash-integration-spec.md` — tier-to-Cedar mapping spec
- Maps Enforced/Autonomous/Propose/Escalate to Cedar permit/forbid patterns
- Entity model, generation algorithm, policy triggers
- Leash-present and Leash-absent deployment scenarios with 4-phase migration
- 3 example Cedar policies: implementer, security-agent, standing-orders

## Test plan
- [x] 38 tests pass (spec coverage, example validation, tier coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)