### PR TITLE
feat(sec-14): cascade containment circuit breakers

### DIFF
--- a/admiral/security/cascade-containment.test.ts
+++ b/admiral/security/cascade-containment.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import { CascadeContainment } from "./cascade-containment";
+
+describe("CascadeContainment", () => {
+	let cc: CascadeContainment;
+
+	beforeEach(() => {
+		cc = new CascadeContainment();
+
+		// Set up usage records
+		cc.recordUsage("agent-1", "mcp-brain");
+		cc.recordUsage("agent-2", "mcp-brain");
+		cc.recordUsage("agent-3", "mcp-fleet");
+		cc.recordUsage("agent-1", "mcp-fleet");
+
+		// Set up entry provenance
+		cc.recordEntryProvenance({
+			entryId: "entry-a",
+			writtenBy: "agent-1",
+			sourceServer: "mcp-brain",
+			readBy: ["agent-3", "agent-4"],
+		});
+		cc.recordEntryProvenance({
+			entryId: "entry-b",
+			writtenBy: "agent-2",
+			sourceServer: "mcp-brain",
+			readBy: [],
+		});
+		cc.recordEntryProvenance({
+			entryId: "entry-c",
+			writtenBy: "agent-3",
+			readBy: ["agent-1"],
+		});
+
+		// Set up delegation
+		cc.recordDelegation("agent-1", "agent-5");
+	});
+
+	describe("triggerBreaker", () => {
+		it("quarantines entries from affected agents", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Malicious tool response detected",
+				severity: "critical",
+			});
+			assert.ok(cc.isQuarantined("entry-a"));
+			assert.ok(cc.isQuarantined("entry-b"));
+			assert.ok(!cc.isQuarantined("entry-c")); // agent-3 didn't use mcp-brain for this entry
+		});
+
+		it("suspends A2A connections for affected agents", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise detected",
+				severity: "critical",
+			});
+			assert.ok(cc.isSuspended("agent-1"));
+			assert.ok(cc.isSuspended("agent-2"));
+			assert.ok(!cc.isSuspended("agent-3")); // agent-3 used mcp-fleet, not mcp-brain
+		});
+
+		it("returns contamination graph", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			assert.equal(graph.rootServer, "mcp-brain");
+			assert.ok(graph.totalAffectedAgents > 0);
+			assert.ok(graph.totalAffectedEntries > 0);
+			assert.ok(graph.nodes.length > 0);
+			assert.ok(graph.edges.length > 0);
+		});
+
+		it("includes server node at depth 0", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			const serverNode = graph.nodes.find((n) => n.type === "server");
+			assert.ok(serverNode);
+			assert.equal(serverNode.depth, 0);
+		});
+
+		it("includes directly affected agents at depth 1", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			const agentNodes = graph.nodes.filter((n) => n.type === "agent" && n.depth === 1);
+			assert.ok(agentNodes.length >= 2); // agent-1 and agent-2
+		});
+
+		it("includes contaminated entries at depth 2", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			const entryNodes = graph.nodes.filter((n) => n.type === "entry");
+			assert.ok(entryNodes.length >= 2);
+		});
+
+		it("includes secondary agents (readers) at depth 3", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			// agent-3 and agent-4 read entry-a (written by agent-1 who used mcp-brain)
+			const secondaryAgents = graph.nodes.filter(
+				(n) => n.type === "agent" && n.depth === 3,
+			);
+			assert.ok(secondaryAgents.length > 0);
+		});
+
+		it("includes delegation chain contamination", () => {
+			const graph = cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Compromise",
+				severity: "critical",
+			});
+			// agent-5 was delegated to by agent-1 (who used mcp-brain)
+			const delegatedNode = graph.nodes.find((n) => n.id === "agent-5");
+			assert.ok(delegatedNode);
+			const delegationEdge = graph.edges.find(
+				(e) => e.to === "agent-5" && e.relationship === "delegated_to",
+			);
+			assert.ok(delegationEdge);
+		});
+	});
+
+	describe("isCompromised", () => {
+		it("returns false before trigger", () => {
+			assert.equal(cc.isCompromised("mcp-brain"), false);
+		});
+
+		it("returns true after trigger", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Test",
+				severity: "high",
+			});
+			assert.equal(cc.isCompromised("mcp-brain"), true);
+		});
+	});
+
+	describe("restoration", () => {
+		it("restores quarantined entry", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Test",
+				severity: "high",
+			});
+			assert.ok(cc.isQuarantined("entry-a"));
+			cc.restoreEntry("entry-a");
+			assert.ok(!cc.isQuarantined("entry-a"));
+		});
+
+		it("restores suspended agent", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Test",
+				severity: "high",
+			});
+			assert.ok(cc.isSuspended("agent-1"));
+			cc.restoreAgent("agent-1");
+			assert.ok(!cc.isSuspended("agent-1"));
+		});
+	});
+
+	describe("getters", () => {
+		it("returns quarantined entries", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Test",
+				severity: "high",
+			});
+			const entries = cc.getQuarantinedEntries();
+			assert.ok(entries.length >= 2);
+		});
+
+		it("returns suspended agents", () => {
+			cc.triggerBreaker({
+				serverId: "mcp-brain",
+				detectedAt: new Date().toISOString(),
+				reason: "Test",
+				severity: "high",
+			});
+			const agents = cc.getSuspendedAgents();
+			assert.ok(agents.length >= 2);
+		});
+	});
+});

--- a/admiral/security/cascade-containment.ts
+++ b/admiral/security/cascade-containment.ts
@@ -1,0 +1,337 @@
+/**
+ * Cascade Containment Circuit Breakers (SEC-14)
+ *
+ * On MCP server compromise:
+ * 1. Quarantine all Brain entries written by agents that used the flagged server
+ * 2. Suspend A2A connections for affected agents
+ * 3. Compute contamination graph tracing data lineage through agents and entries
+ *
+ * Analogous to epoch-based trust revocation applied to data integrity.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Compromised server record */
+export interface CompromisedServer {
+	serverId: string;
+	detectedAt: string;
+	reason: string;
+	severity: "critical" | "high" | "medium";
+}
+
+/** Quarantined Brain entry */
+export interface QuarantinedEntry {
+	entryId: string;
+	originalServer: string;
+	writtenByAgent: string;
+	quarantinedAt: string;
+	reason: string;
+	status: "quarantined" | "reviewed" | "restored" | "deleted";
+}
+
+/** Agent connection suspension */
+export interface SuspendedConnection {
+	agentId: string;
+	suspendedAt: string;
+	reason: string;
+	affectedServer: string;
+	status: "suspended" | "reviewed" | "restored";
+}
+
+/** Node in the contamination graph */
+export interface ContaminationNode {
+	type: "server" | "agent" | "entry";
+	id: string;
+	contaminatedAt: string;
+	contaminationPath: string[];
+	depth: number;
+}
+
+/** Edge in the contamination graph */
+export interface ContaminationEdge {
+	from: string;
+	to: string;
+	relationship: "used_server" | "wrote_entry" | "read_entry" | "delegated_to" | "received_a2a";
+}
+
+/** Full contamination graph */
+export interface ContaminationGraph {
+	nodes: ContaminationNode[];
+	edges: ContaminationEdge[];
+	rootServer: string;
+	computedAt: string;
+	totalAffectedAgents: number;
+	totalAffectedEntries: number;
+}
+
+/** Agent-server usage record */
+export interface AgentServerUsage {
+	agentId: string;
+	serverId: string;
+	lastUsed: string;
+}
+
+/** Brain entry provenance record */
+export interface EntryProvenance {
+	entryId: string;
+	writtenBy: string;
+	sourceServer?: string;
+	readBy: string[];
+}
+
+// ---------------------------------------------------------------------------
+// CascadeContainment
+// ---------------------------------------------------------------------------
+
+export class CascadeContainment {
+	private compromisedServers: Map<string, CompromisedServer> = new Map();
+	private quarantinedEntries: Map<string, QuarantinedEntry> = new Map();
+	private suspendedConnections: Map<string, SuspendedConnection> = new Map();
+	private agentServerUsage: AgentServerUsage[] = [];
+	private entryProvenance: EntryProvenance[] = [];
+	private agentDelegations: Array<{ from: string; to: string }> = [];
+
+	/** Register agent-server usage for tracking */
+	recordUsage(agentId: string, serverId: string): void {
+		this.agentServerUsage.push({
+			agentId,
+			serverId,
+			lastUsed: new Date().toISOString(),
+		});
+	}
+
+	/** Register Brain entry provenance */
+	recordEntryProvenance(entry: EntryProvenance): void {
+		this.entryProvenance.push(entry);
+	}
+
+	/** Register agent delegation */
+	recordDelegation(fromAgent: string, toAgent: string): void {
+		this.agentDelegations.push({ from: fromAgent, to: toAgent });
+	}
+
+	/**
+	 * Trigger circuit breaker on server compromise.
+	 * Returns the contamination graph for the incident.
+	 */
+	triggerBreaker(server: CompromisedServer): ContaminationGraph {
+		this.compromisedServers.set(server.serverId, server);
+
+		// Step 1: Find all agents that used this server
+		const affectedAgentIds = new Set<string>();
+		for (const usage of this.agentServerUsage) {
+			if (usage.serverId === server.serverId) {
+				affectedAgentIds.add(usage.agentId);
+			}
+		}
+
+		// Step 2: Quarantine Brain entries from affected agents
+		for (const prov of this.entryProvenance) {
+			if (affectedAgentIds.has(prov.writtenBy) || prov.sourceServer === server.serverId) {
+				this.quarantinedEntries.set(prov.entryId, {
+					entryId: prov.entryId,
+					originalServer: prov.sourceServer ?? server.serverId,
+					writtenByAgent: prov.writtenBy,
+					quarantinedAt: new Date().toISOString(),
+					reason: `Server '${server.serverId}' compromised: ${server.reason}`,
+					status: "quarantined",
+				});
+			}
+		}
+
+		// Step 3: Suspend A2A connections for affected agents
+		for (const agentId of affectedAgentIds) {
+			this.suspendedConnections.set(agentId, {
+				agentId,
+				suspendedAt: new Date().toISOString(),
+				reason: `Agent used compromised server '${server.serverId}'`,
+				affectedServer: server.serverId,
+				status: "suspended",
+			});
+		}
+
+		// Step 4: Compute contamination graph
+		return this.computeContaminationGraph(server.serverId, affectedAgentIds);
+	}
+
+	/** Compute the contamination graph for a compromised server */
+	private computeContaminationGraph(
+		serverId: string,
+		directAgents: Set<string>,
+	): ContaminationGraph {
+		const nodes: ContaminationNode[] = [];
+		const edges: ContaminationEdge[] = [];
+		const visited = new Set<string>();
+
+		// Root: the compromised server
+		nodes.push({
+			type: "server",
+			id: serverId,
+			contaminatedAt: new Date().toISOString(),
+			contaminationPath: [serverId],
+			depth: 0,
+		});
+		visited.add(`server:${serverId}`);
+
+		// Depth 1: directly affected agents
+		for (const agentId of directAgents) {
+			const key = `agent:${agentId}`;
+			if (!visited.has(key)) {
+				nodes.push({
+					type: "agent",
+					id: agentId,
+					contaminatedAt: new Date().toISOString(),
+					contaminationPath: [serverId, agentId],
+					depth: 1,
+				});
+				edges.push({
+					from: serverId,
+					to: agentId,
+					relationship: "used_server",
+				});
+				visited.add(key);
+			}
+		}
+
+		// Depth 2: entries written by affected agents
+		const affectedEntryIds = new Set<string>();
+		for (const prov of this.entryProvenance) {
+			if (directAgents.has(prov.writtenBy) || prov.sourceServer === serverId) {
+				const key = `entry:${prov.entryId}`;
+				if (!visited.has(key)) {
+					nodes.push({
+						type: "entry",
+						id: prov.entryId,
+						contaminatedAt: new Date().toISOString(),
+						contaminationPath: [serverId, prov.writtenBy, prov.entryId],
+						depth: 2,
+					});
+					edges.push({
+						from: prov.writtenBy,
+						to: prov.entryId,
+						relationship: "wrote_entry",
+					});
+					visited.add(key);
+					affectedEntryIds.add(prov.entryId);
+				}
+			}
+		}
+
+		// Depth 3: agents that read affected entries (secondary contamination)
+		const secondaryAgents = new Set<string>();
+		for (const prov of this.entryProvenance) {
+			if (affectedEntryIds.has(prov.entryId)) {
+				for (const readerId of prov.readBy) {
+					if (!directAgents.has(readerId)) {
+						secondaryAgents.add(readerId);
+						const key = `agent:${readerId}`;
+						if (!visited.has(key)) {
+							nodes.push({
+								type: "agent",
+								id: readerId,
+								contaminatedAt: new Date().toISOString(),
+								contaminationPath: [serverId, "...", prov.entryId, readerId],
+								depth: 3,
+							});
+							edges.push({
+								from: prov.entryId,
+								to: readerId,
+								relationship: "read_entry",
+							});
+							visited.add(key);
+						}
+					}
+				}
+			}
+		}
+
+		// Depth 3+: delegation chain contamination
+		for (const delegation of this.agentDelegations) {
+			if (directAgents.has(delegation.from) || secondaryAgents.has(delegation.from)) {
+				const key = `agent:${delegation.to}`;
+				if (!visited.has(key)) {
+					nodes.push({
+						type: "agent",
+						id: delegation.to,
+						contaminatedAt: new Date().toISOString(),
+						contaminationPath: [serverId, "...", delegation.from, delegation.to],
+						depth: 3,
+					});
+					edges.push({
+						from: delegation.from,
+						to: delegation.to,
+						relationship: "delegated_to",
+					});
+					visited.add(key);
+				}
+			}
+		}
+
+		const totalAgents = nodes.filter((n) => n.type === "agent").length;
+		const totalEntries = nodes.filter((n) => n.type === "entry").length;
+
+		return {
+			nodes,
+			edges,
+			rootServer: serverId,
+			computedAt: new Date().toISOString(),
+			totalAffectedAgents: totalAgents,
+			totalAffectedEntries: totalEntries,
+		};
+	}
+
+	/** Check if a server is compromised */
+	isCompromised(serverId: string): boolean {
+		return this.compromisedServers.has(serverId);
+	}
+
+	/** Check if an entry is quarantined */
+	isQuarantined(entryId: string): boolean {
+		const entry = this.quarantinedEntries.get(entryId);
+		return entry?.status === "quarantined";
+	}
+
+	/** Check if an agent's connections are suspended */
+	isSuspended(agentId: string): boolean {
+		const conn = this.suspendedConnections.get(agentId);
+		return conn?.status === "suspended";
+	}
+
+	/** Restore a quarantined entry after review */
+	restoreEntry(entryId: string): void {
+		const entry = this.quarantinedEntries.get(entryId);
+		if (entry) entry.status = "restored";
+	}
+
+	/** Restore an agent's connections after review */
+	restoreAgent(agentId: string): void {
+		const conn = this.suspendedConnections.get(agentId);
+		if (conn) conn.status = "restored";
+	}
+
+	/** Get all quarantined entries */
+	getQuarantinedEntries(): QuarantinedEntry[] {
+		return Array.from(this.quarantinedEntries.values()).filter(
+			(e) => e.status === "quarantined",
+		);
+	}
+
+	/** Get all suspended agents */
+	getSuspendedAgents(): SuspendedConnection[] {
+		return Array.from(this.suspendedConnections.values()).filter(
+			(c) => c.status === "suspended",
+		);
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.compromisedServers.clear();
+		this.quarantinedEntries.clear();
+		this.suspendedConnections.clear();
+		this.agentServerUsage = [];
+		this.entryProvenance = [];
+		this.agentDelegations = [];
+	}
+}

--- a/plan/todo/07-security-and-robustness.md
+++ b/plan/todo/07-security-and-robustness.md
@@ -38,7 +38,7 @@ Defense in depth for the Admiral Framework: adversarial testing, injection defen
 ## MCP/A2A Security
 
 - [x] **S-44: A2A payload content inspection** — *Completed in Phase 10.* — `admiral/security/a2a-inspection.ts` runs A2A messages through Layer 1 (19 injection patterns across 7 categories) and Layer 2 (structural validation, self-messaging prevention, size limits, suspicious metadata). Behavioral anomaly detection via agent baselines. Taint tracking with propagation chains for cascade containment. 17-test suite.
-- [~] **SEC-14: Cascade containment circuit breakers** — On MCP server compromise: (1) quarantine all Brain entries written by agents that used the flagged server (exclude from queries, do not delete), (2) suspend A2A connections for affected agents, (3) compute contamination graph tracing data lineage through agents and Brain entries. Analogous to epoch-based trust revocation applied to data integrity. *(partial — see audit)*
+- [x] **SEC-14: Cascade containment circuit breakers** — *Completed in Phase 10.* — `admiral/security/cascade-containment.ts` implements 3-step circuit breaker: (1) quarantine Brain entries from affected agents (exclude from queries, don't delete), (2) suspend A2A connections for affected agents, (3) compute contamination graph with 4 depth levels (server, agents, entries, secondary agents/delegatees). Supports entry/agent restoration after review. 14-test suite.
 
 ## Advanced Quarantine Layers
 


### PR DESCRIPTION
## Summary
- Add `admiral/security/cascade-containment.ts` — MCP server compromise circuit breaker
- Step 1: Quarantine Brain entries from affected agents (exclude, don't delete)
- Step 2: Suspend A2A connections for affected agents
- Step 3: Compute contamination graph (4 depth levels: server→agents→entries→secondary)
- Supports entry/agent restoration after review

## Test plan
- [x] 14 tests pass (quarantine, suspension, graph computation, restoration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)