### PR TITLE
feat(b-19): brain entry sensitivity classification

### DIFF
--- a/admiral/brain/sensitivity-classification.test.ts
+++ b/admiral/brain/sensitivity-classification.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import { SensitivityClassifier } from "./sensitivity-classification";
+
+describe("SensitivityClassifier", () => {
+	let classifier: SensitivityClassifier;
+
+	beforeEach(() => {
+		classifier = new SensitivityClassifier();
+		classifier.grantClearance({
+			agentId: "public-agent",
+			clearanceLevel: "PUBLIC",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+		classifier.grantClearance({
+			agentId: "internal-agent",
+			clearanceLevel: "INTERNAL",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+		classifier.grantClearance({
+			agentId: "admin-agent",
+			clearanceLevel: "RESTRICTED",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+	});
+
+	describe("classify", () => {
+		it("classifies an entry", () => {
+			const result = classifier.classify("e1", "CONFIDENTIAL", "agent-1");
+			assert.equal(result.entryId, "e1");
+			assert.equal(result.sensitivity, "CONFIDENTIAL");
+			assert.ok(result.classifiedAt);
+		});
+
+		it("returns default level for unclassified entries", () => {
+			assert.equal(classifier.getLevel("unknown"), "INTERNAL");
+		});
+
+		it("returns classified level", () => {
+			classifier.classify("e1", "RESTRICTED", "agent-1");
+			assert.equal(classifier.getLevel("e1"), "RESTRICTED");
+		});
+	});
+
+	describe("access control", () => {
+		it("allows access when clearance >= sensitivity", () => {
+			classifier.classify("e1", "INTERNAL", "agent-1");
+			const result = classifier.checkAccess("internal-agent", "e1");
+			assert.equal(result.allowed, true);
+		});
+
+		it("allows higher clearance to access lower sensitivity", () => {
+			classifier.classify("e1", "PUBLIC", "agent-1");
+			const result = classifier.checkAccess("admin-agent", "e1");
+			assert.equal(result.allowed, true);
+		});
+
+		it("blocks access when clearance < sensitivity", () => {
+			classifier.classify("e1", "RESTRICTED", "agent-1");
+			const result = classifier.checkAccess("public-agent", "e1");
+			assert.equal(result.allowed, false);
+			assert.ok(result.reason.includes("insufficient"));
+		});
+
+		it("blocks INTERNAL entries for PUBLIC agents", () => {
+			classifier.classify("e1", "INTERNAL", "agent-1");
+			const result = classifier.checkAccess("public-agent", "e1");
+			assert.equal(result.allowed, false);
+		});
+
+		it("defaults unregistered agents to PUBLIC clearance", () => {
+			classifier.classify("e1", "INTERNAL", "agent-1");
+			const result = classifier.checkAccess("unknown-agent", "e1");
+			assert.equal(result.allowed, false);
+			assert.equal(result.agentClearance, "PUBLIC");
+		});
+	});
+
+	describe("filterByAccess", () => {
+		it("filters entries by agent clearance", () => {
+			classifier.classify("e1", "PUBLIC", "a");
+			classifier.classify("e2", "INTERNAL", "a");
+			classifier.classify("e3", "CONFIDENTIAL", "a");
+			classifier.classify("e4", "RESTRICTED", "a");
+
+			const publicVisible = classifier.filterByAccess(
+				["e1", "e2", "e3", "e4"],
+				"public-agent",
+			);
+			assert.deepEqual(publicVisible, ["e1"]);
+
+			const internalVisible = classifier.filterByAccess(
+				["e1", "e2", "e3", "e4"],
+				"internal-agent",
+			);
+			assert.deepEqual(internalVisible, ["e1", "e2"]);
+
+			const adminVisible = classifier.filterByAccess(
+				["e1", "e2", "e3", "e4"],
+				"admin-agent",
+			);
+			assert.deepEqual(adminVisible, ["e1", "e2", "e3", "e4"]);
+		});
+	});
+
+	describe("reclassify", () => {
+		it("changes entry sensitivity", () => {
+			classifier.classify("e1", "PUBLIC", "a");
+			const record = classifier.reclassify(
+				"e1",
+				"CONFIDENTIAL",
+				"admin",
+				"Contains sensitive data",
+			);
+			assert.equal(record.previousLevel, "PUBLIC");
+			assert.equal(record.newLevel, "CONFIDENTIAL");
+			assert.equal(classifier.getLevel("e1"), "CONFIDENTIAL");
+		});
+
+		it("records in audit log", () => {
+			classifier.classify("e1", "PUBLIC", "a");
+			classifier.reclassify("e1", "INTERNAL", "admin", "Upgraded");
+			const log = classifier.getReclassificationLog();
+			assert.equal(log.length, 1);
+			assert.equal(log[0].reason, "Upgraded");
+		});
+	});
+
+	describe("bulkReclassify", () => {
+		it("reclassifies multiple entries", () => {
+			classifier.classify("e1", "PUBLIC", "a");
+			classifier.classify("e2", "PUBLIC", "a");
+			classifier.classify("e3", "INTERNAL", "a");
+
+			const records = classifier.bulkReclassify(
+				["e1", "e2", "e3"],
+				"CONFIDENTIAL",
+				"admin",
+				"Bulk upgrade",
+			);
+			assert.equal(records.length, 3);
+			assert.equal(classifier.getLevel("e1"), "CONFIDENTIAL");
+			assert.equal(classifier.getLevel("e2"), "CONFIDENTIAL");
+			assert.equal(classifier.getLevel("e3"), "CONFIDENTIAL");
+		});
+	});
+
+	describe("getEntriesByLevel", () => {
+		it("returns entries at specific level", () => {
+			classifier.classify("e1", "PUBLIC", "a");
+			classifier.classify("e2", "PUBLIC", "a");
+			classifier.classify("e3", "INTERNAL", "a");
+
+			assert.equal(classifier.getEntriesByLevel("PUBLIC").length, 2);
+			assert.equal(classifier.getEntriesByLevel("INTERNAL").length, 1);
+			assert.equal(classifier.getEntriesByLevel("RESTRICTED").length, 0);
+		});
+	});
+
+	describe("static utilities", () => {
+		it("compareLevels orders correctly", () => {
+			assert.ok(SensitivityClassifier.compareLevels("PUBLIC", "RESTRICTED") < 0);
+			assert.ok(SensitivityClassifier.compareLevels("RESTRICTED", "PUBLIC") > 0);
+			assert.equal(SensitivityClassifier.compareLevels("INTERNAL", "INTERNAL"), 0);
+		});
+
+		it("isValidLevel validates", () => {
+			assert.equal(SensitivityClassifier.isValidLevel("PUBLIC"), true);
+			assert.equal(SensitivityClassifier.isValidLevel("SECRET"), false);
+		});
+	});
+});

--- a/admiral/brain/sensitivity-classification.ts
+++ b/admiral/brain/sensitivity-classification.ts
@@ -1,0 +1,210 @@
+/**
+ * Brain Entry Sensitivity Classification (B-19)
+ *
+ * Assigns sensitivity levels (public/internal/confidential/restricted)
+ * to brain entries. Queries filter by agent clearance level. Supports
+ * bulk reclassification with audit trail.
+ *
+ * Uses the same SensitivityLevel taxonomy as S-45 data classification.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Sensitivity levels matching S-45 taxonomy */
+export type SensitivityLevel = "PUBLIC" | "INTERNAL" | "CONFIDENTIAL" | "RESTRICTED";
+
+/** Numeric ordering for clearance comparison */
+const LEVEL_ORDER: Record<SensitivityLevel, number> = {
+	PUBLIC: 0,
+	INTERNAL: 1,
+	CONFIDENTIAL: 2,
+	RESTRICTED: 3,
+};
+
+/** Agent clearance record */
+export interface AgentClearance {
+	agentId: string;
+	clearanceLevel: SensitivityLevel;
+	grantedBy: string;
+	grantedAt: string;
+}
+
+/** Classified brain entry metadata */
+export interface ClassifiedEntry {
+	entryId: string;
+	sensitivity: SensitivityLevel;
+	classifiedBy: string;
+	classifiedAt: string;
+	reason?: string;
+}
+
+/** Reclassification record */
+export interface ReclassificationRecord {
+	entryId: string;
+	previousLevel: SensitivityLevel;
+	newLevel: SensitivityLevel;
+	reclassifiedBy: string;
+	reclassifiedAt: string;
+	reason: string;
+}
+
+/** Access check result */
+export interface AccessCheckResult {
+	allowed: boolean;
+	agentId: string;
+	entryId: string;
+	agentClearance: SensitivityLevel;
+	entrySensitivity: SensitivityLevel;
+	reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// SensitivityClassifier
+// ---------------------------------------------------------------------------
+
+export class SensitivityClassifier {
+	private classifications: Map<string, ClassifiedEntry> = new Map();
+	private clearances: Map<string, AgentClearance> = new Map();
+	private reclassificationLog: ReclassificationRecord[] = [];
+	private defaultLevel: SensitivityLevel;
+
+	constructor(defaultLevel: SensitivityLevel = "INTERNAL") {
+		this.defaultLevel = defaultLevel;
+	}
+
+	/** Classify a brain entry with a sensitivity level */
+	classify(
+		entryId: string,
+		level: SensitivityLevel,
+		classifiedBy: string,
+		reason?: string,
+	): ClassifiedEntry {
+		const entry: ClassifiedEntry = {
+			entryId,
+			sensitivity: level,
+			classifiedBy,
+			classifiedAt: new Date().toISOString(),
+			reason,
+		};
+		this.classifications.set(entryId, entry);
+		return entry;
+	}
+
+	/** Get the sensitivity level of an entry */
+	getLevel(entryId: string): SensitivityLevel {
+		return this.classifications.get(entryId)?.sensitivity ?? this.defaultLevel;
+	}
+
+	/** Get classification details */
+	getClassification(entryId: string): ClassifiedEntry | undefined {
+		return this.classifications.get(entryId);
+	}
+
+	/** Register an agent's clearance level */
+	grantClearance(clearance: AgentClearance): void {
+		this.clearances.set(clearance.agentId, clearance);
+	}
+
+	/** Get an agent's clearance level */
+	getClearance(agentId: string): SensitivityLevel {
+		return this.clearances.get(agentId)?.clearanceLevel ?? "PUBLIC";
+	}
+
+	/** Check if an agent can access an entry */
+	checkAccess(agentId: string, entryId: string): AccessCheckResult {
+		const agentClearance = this.getClearance(agentId);
+		const entrySensitivity = this.getLevel(entryId);
+
+		const agentOrder = LEVEL_ORDER[agentClearance];
+		const entryOrder = LEVEL_ORDER[entrySensitivity];
+
+		const allowed = agentOrder >= entryOrder;
+
+		return {
+			allowed,
+			agentId,
+			entryId,
+			agentClearance,
+			entrySensitivity,
+			reason: allowed
+				? `${agentClearance} clearance sufficient for ${entrySensitivity} entry`
+				: `${agentClearance} clearance insufficient for ${entrySensitivity} entry`,
+		};
+	}
+
+	/** Filter entries by agent clearance */
+	filterByAccess(entryIds: string[], agentId: string): string[] {
+		return entryIds.filter((id) => this.checkAccess(agentId, id).allowed);
+	}
+
+	/** Reclassify an entry to a different level */
+	reclassify(
+		entryId: string,
+		newLevel: SensitivityLevel,
+		reclassifiedBy: string,
+		reason: string,
+	): ReclassificationRecord {
+		const previousLevel = this.getLevel(entryId);
+
+		const record: ReclassificationRecord = {
+			entryId,
+			previousLevel,
+			newLevel,
+			reclassifiedBy,
+			reclassifiedAt: new Date().toISOString(),
+			reason,
+		};
+		this.reclassificationLog.push(record);
+
+		this.classify(entryId, newLevel, reclassifiedBy, reason);
+
+		return record;
+	}
+
+	/** Bulk reclassify entries matching a filter */
+	bulkReclassify(
+		entryIds: string[],
+		newLevel: SensitivityLevel,
+		reclassifiedBy: string,
+		reason: string,
+	): ReclassificationRecord[] {
+		return entryIds.map((id) =>
+			this.reclassify(id, newLevel, reclassifiedBy, reason),
+		);
+	}
+
+	/** Get all entries at a specific sensitivity level */
+	getEntriesByLevel(level: SensitivityLevel): string[] {
+		const result: string[] = [];
+		for (const [entryId, classification] of this.classifications) {
+			if (classification.sensitivity === level) {
+				result.push(entryId);
+			}
+		}
+		return result;
+	}
+
+	/** Get reclassification audit log */
+	getReclassificationLog(): ReclassificationRecord[] {
+		return [...this.reclassificationLog];
+	}
+
+	/** Compare two sensitivity levels */
+	static compareLevels(a: SensitivityLevel, b: SensitivityLevel): number {
+		return LEVEL_ORDER[a] - LEVEL_ORDER[b];
+	}
+
+	/** Check if a level is valid */
+	static isValidLevel(level: string): level is SensitivityLevel {
+		return level in LEVEL_ORDER;
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.classifications.clear();
+		this.clearances.clear();
+		this.reclassificationLog = [];
+	}
+}

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -59,7 +59,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 - [ ] **B-16** Multi-signal retrieval pipeline — keyword (FTS), semantic (pgvector), temporal (recency), link-based (graph proximity); configurable weights, query-time signal selection
 - [x] **B-17** Multi-hop link traversal — supports/contradicts/supersedes/related_to relationships, configurable depth, cycle detection, traversal path in results
 - [~] **B-18** Quarantine integration — external content passes 5-layer pipeline before brain ingestion, `quarantine_status` metadata *(partial — see audit)*
-- [ ] **B-19** Sensitivity classification — public/internal/confidential/restricted levels, queries filter by agent clearance, bulk reclassification
+- [x] **B-19** Sensitivity classification — *Completed in Phase 10.* — `admiral/brain/sensitivity-classification.ts` with 4-level taxonomy (PUBLIC/INTERNAL/CONFIDENTIAL/RESTRICTED), agent clearance grants, access checking, query filtering by clearance, single and bulk reclassification with audit log. 15-test suite.
 - [ ] **B-20** Audit logging — append-only log of all operations, queryable by time/agent/operation/entry, configurable retention
 
 ## Graduation & Provenance


### PR DESCRIPTION
## Summary
- Add `admiral/brain/sensitivity-classification.ts`
- 4-level taxonomy: PUBLIC/INTERNAL/CONFIDENTIAL/RESTRICTED
- Agent clearance grants and access checking
- Query filtering by clearance level
- Single and bulk reclassification with audit trail

## Test plan
- [x] 15 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)