### PR TITLE
feat(b-20): brain audit logging

### DIFF
--- a/admiral/brain/audit-logging.test.ts
+++ b/admiral/brain/audit-logging.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import { BrainAuditLog } from "./audit-logging";
+
+describe("BrainAuditLog", () => {
+	let log: BrainAuditLog;
+
+	beforeEach(() => {
+		log = new BrainAuditLog();
+	});
+
+	describe("record", () => {
+		it("records an operation", () => {
+			const entry = log.record("insert", "agent-1", "entry-1", { title: "Test" });
+			assert.ok(entry.id);
+			assert.equal(entry.operation, "insert");
+			assert.equal(entry.agentId, "agent-1");
+			assert.equal(entry.entryId, "entry-1");
+			assert.ok(entry.timestamp > 0);
+		});
+
+		it("increments count", () => {
+			log.record("insert", "a1");
+			log.record("query", "a2");
+			assert.equal(log.getCount(), 2);
+		});
+
+		it("records without entryId", () => {
+			const entry = log.record("query", "agent-1");
+			assert.equal(entry.entryId, undefined);
+		});
+	});
+
+	describe("query", () => {
+		beforeEach(() => {
+			log.record("insert", "agent-1", "e1");
+			log.record("query", "agent-2", "e1");
+			log.record("update", "agent-1", "e1");
+			log.record("delete", "agent-1", "e2");
+		});
+
+		it("returns all entries without filter", () => {
+			assert.equal(log.query({}).length, 4);
+		});
+
+		it("filters by operation", () => {
+			const result = log.query({ operation: "insert" });
+			assert.equal(result.length, 1);
+			assert.equal(result[0].operation, "insert");
+		});
+
+		it("filters by agentId", () => {
+			const result = log.query({ agentId: "agent-1" });
+			assert.equal(result.length, 3);
+		});
+
+		it("filters by entryId", () => {
+			const result = log.query({ entryId: "e1" });
+			assert.equal(result.length, 3);
+		});
+
+		it("applies limit", () => {
+			const result = log.query({ limit: 2 });
+			assert.equal(result.length, 2);
+		});
+	});
+
+	describe("getEntryHistory", () => {
+		it("returns operations for a specific entry", () => {
+			log.record("insert", "a1", "e1");
+			log.record("update", "a1", "e1");
+			log.record("insert", "a1", "e2");
+
+			const history = log.getEntryHistory("e1");
+			assert.equal(history.length, 2);
+		});
+	});
+
+	describe("getAgentActivity", () => {
+		it("returns operations by a specific agent", () => {
+			log.record("insert", "agent-1", "e1");
+			log.record("query", "agent-2");
+			log.record("update", "agent-1", "e1");
+
+			const activity = log.getAgentActivity("agent-1");
+			assert.equal(activity.length, 2);
+		});
+	});
+
+	describe("getSummary", () => {
+		it("returns correct summary", () => {
+			log.record("insert", "a1", "e1");
+			log.record("query", "a2");
+			log.record("insert", "a1", "e2");
+
+			const summary = log.getSummary();
+			assert.equal(summary.totalEntries, 3);
+			assert.equal(summary.operationCounts.insert, 2);
+			assert.equal(summary.operationCounts.query, 1);
+			assert.equal(summary.uniqueAgents, 2);
+			assert.ok(summary.oldestEntry);
+			assert.ok(summary.newestEntry);
+		});
+
+		it("returns empty summary for empty log", () => {
+			const summary = log.getSummary();
+			assert.equal(summary.totalEntries, 0);
+			assert.equal(summary.uniqueAgents, 0);
+		});
+	});
+
+	describe("retention policy", () => {
+		it("enforces maxEntries", () => {
+			const limited = new BrainAuditLog({ maxEntries: 3 });
+			limited.record("insert", "a1");
+			limited.record("insert", "a1");
+			limited.record("insert", "a1");
+			limited.record("insert", "a1");
+			limited.record("insert", "a1");
+
+			assert.equal(limited.getCount(), 3);
+		});
+
+		it("can update retention policy", () => {
+			log.record("insert", "a1");
+			log.record("insert", "a1");
+			log.record("insert", "a1");
+
+			log.setRetention({ maxEntries: 2 });
+			assert.equal(log.getCount(), 2);
+		});
+	});
+
+	describe("exportJsonl", () => {
+		it("exports as JSONL", () => {
+			log.record("insert", "a1", "e1");
+			log.record("query", "a2");
+
+			const jsonl = log.exportJsonl();
+			const lines = jsonl.split("\n");
+			assert.equal(lines.length, 2);
+			assert.ok(JSON.parse(lines[0]).operation === "insert");
+			assert.ok(JSON.parse(lines[1]).operation === "query");
+		});
+	});
+});

--- a/admiral/brain/audit-logging.ts
+++ b/admiral/brain/audit-logging.ts
@@ -1,0 +1,199 @@
+/**
+ * Brain Audit Logging (B-20)
+ *
+ * Append-only log of all Brain operations, queryable by time, agent,
+ * operation type, and entry ID. Configurable retention policy.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Brain operation types */
+export type BrainOperation =
+	| "insert"
+	| "update"
+	| "delete"
+	| "query"
+	| "retrieve"
+	| "link_add"
+	| "link_remove"
+	| "strengthen"
+	| "supersede"
+	| "purge"
+	| "export"
+	| "import"
+	| "classify"
+	| "reclassify";
+
+/** Single audit log entry */
+export interface BrainAuditEntry {
+	id: string;
+	operation: BrainOperation;
+	entryId?: string;
+	agentId: string;
+	timestamp: number;
+	details: Record<string, unknown>;
+}
+
+/** Query filter for audit log */
+export interface AuditQuery {
+	since?: number;
+	until?: number;
+	agentId?: string;
+	operation?: BrainOperation;
+	entryId?: string;
+	limit?: number;
+}
+
+/** Retention policy */
+export interface RetentionPolicy {
+	maxEntries?: number;
+	maxAgeMs?: number;
+}
+
+/** Audit summary statistics */
+export interface AuditSummary {
+	totalEntries: number;
+	operationCounts: Partial<Record<BrainOperation, number>>;
+	uniqueAgents: number;
+	oldestEntry?: number;
+	newestEntry?: number;
+}
+
+// ---------------------------------------------------------------------------
+// BrainAuditLog
+// ---------------------------------------------------------------------------
+
+let auditIdCounter = 0;
+
+export class BrainAuditLog {
+	private entries: BrainAuditEntry[] = [];
+	private retention: RetentionPolicy;
+
+	constructor(retention?: RetentionPolicy) {
+		this.retention = retention ?? {};
+	}
+
+	/** Record a brain operation */
+	record(
+		operation: BrainOperation,
+		agentId: string,
+		entryId?: string,
+		details?: Record<string, unknown>,
+	): BrainAuditEntry {
+		const entry: BrainAuditEntry = {
+			id: `audit-${++auditIdCounter}`,
+			operation,
+			entryId,
+			agentId,
+			timestamp: Date.now(),
+			details: details ?? {},
+		};
+
+		this.entries.push(entry);
+		this.enforceRetention();
+
+		return entry;
+	}
+
+	/** Query the audit log with filters */
+	query(filter: AuditQuery): BrainAuditEntry[] {
+		let result = [...this.entries];
+
+		if (filter.since !== undefined) {
+			result = result.filter((e) => e.timestamp >= filter.since!);
+		}
+
+		if (filter.until !== undefined) {
+			result = result.filter((e) => e.timestamp <= filter.until!);
+		}
+
+		if (filter.agentId !== undefined) {
+			result = result.filter((e) => e.agentId === filter.agentId);
+		}
+
+		if (filter.operation !== undefined) {
+			result = result.filter((e) => e.operation === filter.operation);
+		}
+
+		if (filter.entryId !== undefined) {
+			result = result.filter((e) => e.entryId === filter.entryId);
+		}
+
+		if (filter.limit !== undefined) {
+			result = result.slice(-filter.limit);
+		}
+
+		return result;
+	}
+
+	/** Get operations for a specific entry */
+	getEntryHistory(entryId: string): BrainAuditEntry[] {
+		return this.entries.filter((e) => e.entryId === entryId);
+	}
+
+	/** Get operations by a specific agent */
+	getAgentActivity(agentId: string): BrainAuditEntry[] {
+		return this.entries.filter((e) => e.agentId === agentId);
+	}
+
+	/** Get summary statistics */
+	getSummary(): AuditSummary {
+		const operationCounts: Partial<Record<BrainOperation, number>> = {};
+		const agents = new Set<string>();
+
+		for (const entry of this.entries) {
+			operationCounts[entry.operation] =
+				(operationCounts[entry.operation] ?? 0) + 1;
+			agents.add(entry.agentId);
+		}
+
+		return {
+			totalEntries: this.entries.length,
+			operationCounts,
+			uniqueAgents: agents.size,
+			oldestEntry: this.entries.length > 0 ? this.entries[0].timestamp : undefined,
+			newestEntry:
+				this.entries.length > 0
+					? this.entries[this.entries.length - 1].timestamp
+					: undefined,
+		};
+	}
+
+	/** Get total entry count */
+	getCount(): number {
+		return this.entries.length;
+	}
+
+	/** Update retention policy */
+	setRetention(policy: RetentionPolicy): void {
+		this.retention = policy;
+		this.enforceRetention();
+	}
+
+	/** Enforce retention policy by removing old/excess entries */
+	private enforceRetention(): void {
+		if (this.retention.maxAgeMs !== undefined) {
+			const cutoff = Date.now() - this.retention.maxAgeMs;
+			this.entries = this.entries.filter((e) => e.timestamp >= cutoff);
+		}
+
+		if (
+			this.retention.maxEntries !== undefined &&
+			this.entries.length > this.retention.maxEntries
+		) {
+			this.entries = this.entries.slice(-this.retention.maxEntries);
+		}
+	}
+
+	/** Export log as JSONL string */
+	exportJsonl(): string {
+		return this.entries.map((e) => JSON.stringify(e)).join("\n");
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.entries = [];
+	}
+}

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -60,7 +60,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 - [x] **B-17** Multi-hop link traversal — supports/contradicts/supersedes/related_to relationships, configurable depth, cycle detection, traversal path in results
 - [~] **B-18** Quarantine integration — external content passes 5-layer pipeline before brain ingestion, `quarantine_status` metadata *(partial — see audit)*
 - [x] **B-19** Sensitivity classification — *Completed in Phase 10.* — `admiral/brain/sensitivity-classification.ts` with 4-level taxonomy (PUBLIC/INTERNAL/CONFIDENTIAL/RESTRICTED), agent clearance grants, access checking, query filtering by clearance, single and bulk reclassification with audit log. 15-test suite.
-- [ ] **B-20** Audit logging — append-only log of all operations, queryable by time/agent/operation/entry, configurable retention
+- [x] **B-20** Audit logging — *Completed in Phase 10.* — `admiral/brain/audit-logging.ts` with append-only log, queryable by time/agent/operation/entry, configurable retention (maxEntries, maxAge), JSONL export, summary statistics. 15-test suite.
 
 ## Graduation & Provenance
 


### PR DESCRIPTION
## Summary
- Add `admiral/brain/audit-logging.ts` — append-only operation log
- Queryable by time range, agent, operation type, entry ID
- Configurable retention (maxEntries, maxAge)
- JSONL export and summary statistics

## Test plan
- [x] 15 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)