### PR TITLE
feat(b-14): identity token lifecycle

### DIFF
--- a/admiral/brain/identity-tokens.test.ts
+++ b/admiral/brain/identity-tokens.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import { IdentityTokenManager } from "./identity-tokens";
+
+describe("IdentityTokenManager", () => {
+	let manager: IdentityTokenManager;
+
+	beforeEach(() => {
+		// 1 hour TTL, 1 minute overlap for testing
+		manager = new IdentityTokenManager(3600_000, 60_000);
+	});
+
+	describe("create", () => {
+		it("creates a token with correct fields", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			assert.ok(token.id);
+			assert.equal(token.agentId, "agent-1");
+			assert.ok(token.token.startsWith("ait_"));
+			assert.equal(token.status, "active");
+			assert.ok(token.expiresAt > token.createdAt);
+		});
+
+		it("uses custom TTL", () => {
+			const token = manager.create({ agentId: "agent-1", ttlMs: 5000 });
+			assert.equal(token.expiresAt - token.createdAt, 5000);
+		});
+
+		it("creates unique tokens", () => {
+			const t1 = manager.create({ agentId: "agent-1" });
+			const t2 = manager.create({ agentId: "agent-1" });
+			assert.notEqual(t1.id, t2.id);
+			assert.notEqual(t1.token, t2.token);
+		});
+	});
+
+	describe("validate", () => {
+		it("validates active token", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			const result = manager.validate(token.token);
+			assert.equal(result.valid, true);
+			assert.equal(result.agentId, "agent-1");
+		});
+
+		it("rejects unknown token", () => {
+			const result = manager.validate("ait_nonexistent");
+			assert.equal(result.valid, false);
+			assert.ok(result.reason.includes("not found"));
+		});
+
+		it("rejects expired token", () => {
+			const token = manager.create({ agentId: "agent-1", ttlMs: 1000 });
+			const futureTime = Date.now() + 2000;
+			const result = manager.validate(token.token, futureTime);
+			assert.equal(result.valid, false);
+			assert.ok(result.reason.includes("expired"));
+		});
+
+		it("rejects revoked token", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			manager.revoke(token.id);
+			const result = manager.validate(token.token);
+			assert.equal(result.valid, false);
+			assert.ok(result.reason.includes("revoked"));
+		});
+	});
+
+	describe("rotate", () => {
+		it("creates new token and marks old as rotated", () => {
+			const original = manager.create({ agentId: "agent-1" });
+			const result = manager.rotate(original.id);
+
+			assert.ok(result);
+			assert.equal(result.oldToken.status, "rotated");
+			assert.equal(result.newToken.status, "active");
+			assert.equal(result.newToken.agentId, "agent-1");
+			assert.equal(result.oldToken.rotatedTo, result.newToken.id);
+		});
+
+		it("old token valid during overlap window", () => {
+			const original = manager.create({ agentId: "agent-1" });
+			const result = manager.rotate(original.id)!;
+
+			// Old token should still validate during overlap
+			const oldValidation = manager.validate(result.oldToken.token);
+			assert.equal(oldValidation.valid, true);
+			assert.ok(oldValidation.reason.includes("overlap"));
+		});
+
+		it("old token expires after overlap window", () => {
+			const original = manager.create({ agentId: "agent-1" });
+			const result = manager.rotate(original.id)!;
+
+			// After overlap window
+			const futureTime = Date.now() + 120_000;
+			const oldValidation = manager.validate(result.oldToken.token, futureTime);
+			assert.equal(oldValidation.valid, false);
+		});
+
+		it("returns null for non-active token", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			manager.revoke(token.id);
+			assert.equal(manager.rotate(token.id), null);
+		});
+
+		it("returns null for unknown token", () => {
+			assert.equal(manager.rotate("nonexistent"), null);
+		});
+	});
+
+	describe("revoke", () => {
+		it("revokes an active token", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			assert.equal(manager.revoke(token.id), true);
+			assert.equal(manager.getToken(token.id)?.status, "revoked");
+			assert.ok(manager.getToken(token.id)?.revokedAt);
+		});
+
+		it("returns false for already revoked", () => {
+			const token = manager.create({ agentId: "agent-1" });
+			manager.revoke(token.id);
+			assert.equal(manager.revoke(token.id), false);
+		});
+
+		it("returns false for unknown token", () => {
+			assert.equal(manager.revoke("nonexistent"), false);
+		});
+	});
+
+	describe("revokeAllForAgent", () => {
+		it("revokes all tokens for agent", () => {
+			manager.create({ agentId: "agent-1" });
+			manager.create({ agentId: "agent-1" });
+			manager.create({ agentId: "agent-2" });
+
+			const count = manager.revokeAllForAgent("agent-1");
+			assert.equal(count, 2);
+			assert.equal(manager.getActiveTokens("agent-1").length, 0);
+			assert.equal(manager.getActiveTokens("agent-2").length, 1);
+		});
+	});
+
+	describe("getActiveTokens", () => {
+		it("returns only active tokens", () => {
+			manager.create({ agentId: "agent-1" });
+			manager.create({ agentId: "agent-1" });
+			const t3 = manager.create({ agentId: "agent-1" });
+			manager.revoke(t3.id);
+
+			assert.equal(manager.getActiveTokens("agent-1").length, 2);
+		});
+
+		it("returns empty for unknown agent", () => {
+			assert.equal(manager.getActiveTokens("unknown").length, 0);
+		});
+	});
+
+	describe("pruneExpired", () => {
+		it("marks expired tokens", () => {
+			manager.create({ agentId: "agent-1", ttlMs: 1000 });
+			manager.create({ agentId: "agent-1", ttlMs: 1000 });
+			manager.create({ agentId: "agent-1", ttlMs: 999_999 });
+
+			const pruned = manager.pruneExpired(Date.now() + 2000);
+			assert.equal(pruned, 2);
+		});
+	});
+
+	describe("getStats", () => {
+		it("returns correct counts", () => {
+			manager.create({ agentId: "a1" });
+			manager.create({ agentId: "a1" });
+			const t3 = manager.create({ agentId: "a1" });
+			manager.revoke(t3.id);
+
+			const stats = manager.getStats();
+			assert.equal(stats.active, 2);
+			assert.equal(stats.revoked, 1);
+		});
+	});
+});

--- a/admiral/brain/identity-tokens.ts
+++ b/admiral/brain/identity-tokens.ts
@@ -1,0 +1,227 @@
+/**
+ * Identity Token Lifecycle (B-14)
+ *
+ * Create, rotate, and revoke identity tokens for Brain access.
+ * Configurable TTL with overlapping validity windows during rotation
+ * and immediate revocation support.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Identity token */
+export interface IdentityToken {
+	id: string;
+	agentId: string;
+	token: string;
+	createdAt: number;
+	expiresAt: number;
+	revokedAt?: number;
+	rotatedTo?: string;
+	status: "active" | "rotated" | "revoked" | "expired";
+}
+
+/** Token creation options */
+export interface TokenCreateOptions {
+	agentId: string;
+	ttlMs?: number;
+}
+
+/** Token rotation result */
+export interface RotationResult {
+	oldToken: IdentityToken;
+	newToken: IdentityToken;
+	overlapWindowMs: number;
+}
+
+/** Token validation result */
+export interface ValidationResult {
+	valid: boolean;
+	agentId?: string;
+	reason: string;
+	token?: IdentityToken;
+}
+
+// ---------------------------------------------------------------------------
+// IdentityTokenManager
+// ---------------------------------------------------------------------------
+
+/** Default TTL: 24 hours */
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Default overlap window during rotation: 5 minutes */
+const DEFAULT_OVERLAP_MS = 5 * 60 * 1000;
+
+export class IdentityTokenManager {
+	private tokens: Map<string, IdentityToken> = new Map();
+	private tokensByAgent: Map<string, string[]> = new Map();
+	private defaultTtlMs: number;
+	private overlapMs: number;
+
+	constructor(defaultTtlMs?: number, overlapMs?: number) {
+		this.defaultTtlMs = defaultTtlMs ?? DEFAULT_TTL_MS;
+		this.overlapMs = overlapMs ?? DEFAULT_OVERLAP_MS;
+	}
+
+	/** Create a new identity token for an agent */
+	create(options: TokenCreateOptions): IdentityToken {
+		const now = Date.now();
+		const ttl = options.ttlMs ?? this.defaultTtlMs;
+
+		const token: IdentityToken = {
+			id: randomUUID(),
+			agentId: options.agentId,
+			token: `ait_${randomUUID().replace(/-/g, "")}`,
+			createdAt: now,
+			expiresAt: now + ttl,
+			status: "active",
+		};
+
+		this.tokens.set(token.id, token);
+
+		const agentTokens = this.tokensByAgent.get(options.agentId) ?? [];
+		agentTokens.push(token.id);
+		this.tokensByAgent.set(options.agentId, agentTokens);
+
+		return token;
+	}
+
+	/** Rotate a token: create new one, mark old as rotated with overlap window */
+	rotate(tokenId: string, newTtlMs?: number): RotationResult | null {
+		const oldToken = this.tokens.get(tokenId);
+		if (!oldToken || oldToken.status !== "active") return null;
+
+		const now = Date.now();
+
+		// Create new token
+		const newToken = this.create({
+			agentId: oldToken.agentId,
+			ttlMs: newTtlMs,
+		});
+
+		// Mark old token as rotated — it remains valid during overlap window
+		oldToken.status = "rotated";
+		oldToken.rotatedTo = newToken.id;
+		// Extend expiry to overlap window from now (not from original expiry)
+		oldToken.expiresAt = now + this.overlapMs;
+
+		return {
+			oldToken,
+			newToken,
+			overlapWindowMs: this.overlapMs,
+		};
+	}
+
+	/** Immediately revoke a token — no overlap window */
+	revoke(tokenId: string): boolean {
+		const token = this.tokens.get(tokenId);
+		if (!token) return false;
+		if (token.status === "revoked") return false;
+
+		token.status = "revoked";
+		token.revokedAt = Date.now();
+		return true;
+	}
+
+	/** Revoke all tokens for an agent */
+	revokeAllForAgent(agentId: string): number {
+		const tokenIds = this.tokensByAgent.get(agentId) ?? [];
+		let count = 0;
+		for (const id of tokenIds) {
+			if (this.revoke(id)) count++;
+		}
+		return count;
+	}
+
+	/** Validate a token string */
+	validate(tokenString: string, now?: number): ValidationResult {
+		const currentTime = now ?? Date.now();
+
+		for (const token of this.tokens.values()) {
+			if (token.token !== tokenString) continue;
+
+			if (token.status === "revoked") {
+				return { valid: false, reason: "Token has been revoked", token };
+			}
+
+			if (currentTime > token.expiresAt) {
+				// Auto-expire
+				if (token.status === "active" || token.status === "rotated") {
+					token.status = "expired";
+				}
+				return { valid: false, reason: "Token has expired", token };
+			}
+
+			// Active or rotated (still in overlap window)
+			if (token.status === "active" || token.status === "rotated") {
+				return {
+					valid: true,
+					agentId: token.agentId,
+					reason: token.status === "rotated"
+						? "Token valid (in rotation overlap window)"
+						: "Token valid",
+					token,
+				};
+			}
+
+			return { valid: false, reason: `Token status: ${token.status}`, token };
+		}
+
+		return { valid: false, reason: "Token not found" };
+	}
+
+	/** Get a token by ID */
+	getToken(tokenId: string): IdentityToken | undefined {
+		return this.tokens.get(tokenId);
+	}
+
+	/** Get all active tokens for an agent */
+	getActiveTokens(agentId: string): IdentityToken[] {
+		const tokenIds = this.tokensByAgent.get(agentId) ?? [];
+		const now = Date.now();
+		return tokenIds
+			.map((id) => this.tokens.get(id)!)
+			.filter((t) => t && (t.status === "active" || t.status === "rotated") && t.expiresAt > now);
+	}
+
+	/** Clean up expired tokens */
+	pruneExpired(now?: number): number {
+		const currentTime = now ?? Date.now();
+		let pruned = 0;
+
+		for (const token of this.tokens.values()) {
+			if (
+				(token.status === "active" || token.status === "rotated") &&
+				currentTime > token.expiresAt
+			) {
+				token.status = "expired";
+				pruned++;
+			}
+		}
+
+		return pruned;
+	}
+
+	/** Get token count by status */
+	getStats(): Record<string, number> {
+		const stats: Record<string, number> = {
+			active: 0,
+			rotated: 0,
+			revoked: 0,
+			expired: 0,
+		};
+		for (const token of this.tokens.values()) {
+			stats[token.status] = (stats[token.status] ?? 0) + 1;
+		}
+		return stats;
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.tokens.clear();
+		this.tokensByAgent.clear();
+	}
+}

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -51,7 +51,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 
 - [~] **B-12** MCP server scaffold — 8 tool endpoints (brain_record, brain_query, brain_retrieve, brain_strengthen, brain_supersede, brain_status, brain_audit, brain_purge) *(partial — see audit)*
 - [ ] **B-13** Postgres + pgvector schema deployment — migrations, rollback, connection pooling
-- [ ] **B-14** Identity token lifecycle — create, rotate, revoke; configurable TTL, overlapping validity window, immediate revocation
+- [x] **B-14** Identity token lifecycle — *Completed in Phase 10.* — `admiral/brain/identity-tokens.ts` with create (configurable TTL), rotate (overlapping validity window), revoke (immediate), validate, bulk agent revocation, auto-expiry pruning, stats. 20-test suite.
 - [ ] **B-15** Access control enforcement — per-agent per-entry clearance levels (read-only, contributor, admin), write scoping by project, access decisions logged
 
 ## B3 Advanced


### PR DESCRIPTION
## Summary
- Add `admiral/brain/identity-tokens.ts` — token lifecycle management
- Create with configurable TTL, rotate with overlapping validity windows
- Immediate revocation, bulk agent revocation, auto-expiry pruning
- Token validation with status-aware checking

## Test plan
- [x] 20 tests pass locally (create, validate, rotate, revoke, bulk, prune, stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)