### PR TITLE
feat(b-15): brain access control enforcement

### DIFF
--- a/admiral/brain/access-control.test.ts
+++ b/admiral/brain/access-control.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import { AccessController } from "./access-control";
+
+describe("AccessController", () => {
+	let ac: AccessController;
+
+	beforeEach(() => {
+		ac = new AccessController();
+		ac.grant({
+			agentId: "reader",
+			level: "read-only",
+			scope: "*",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+		ac.grant({
+			agentId: "writer",
+			level: "contributor",
+			scope: "helm",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+		ac.grant({
+			agentId: "admin-agent",
+			level: "admin",
+			scope: "*",
+			grantedBy: "Admiral",
+			grantedAt: new Date().toISOString(),
+		});
+	});
+
+	describe("checkAccess", () => {
+		it("allows read for read-only agent", () => {
+			const d = ac.checkAccess("reader", "e1", "read");
+			assert.equal(d.allowed, true);
+		});
+
+		it("blocks write for read-only agent", () => {
+			const d = ac.checkAccess("reader", "e1", "write");
+			assert.equal(d.allowed, false);
+			assert.ok(d.reason.includes("insufficient"));
+		});
+
+		it("allows write for contributor", () => {
+			const d = ac.checkAccess("writer", "e1", "write", "helm");
+			assert.equal(d.allowed, true);
+		});
+
+		it("blocks delete for contributor", () => {
+			const d = ac.checkAccess("writer", "e1", "delete", "helm");
+			assert.equal(d.allowed, false);
+		});
+
+		it("allows all operations for admin", () => {
+			assert.equal(ac.checkAccess("admin-agent", "e1", "read").allowed, true);
+			assert.equal(ac.checkAccess("admin-agent", "e1", "write").allowed, true);
+			assert.equal(ac.checkAccess("admin-agent", "e1", "delete").allowed, true);
+			assert.equal(ac.checkAccess("admin-agent", "e1", "admin").allowed, true);
+		});
+
+		it("defaults unknown agents to read-only", () => {
+			const d = ac.checkAccess("unknown", "e1", "read");
+			assert.equal(d.allowed, true);
+			const d2 = ac.checkAccess("unknown", "e1", "write");
+			assert.equal(d2.allowed, false);
+		});
+	});
+
+	describe("scope-based access", () => {
+		it("respects scope matching", () => {
+			const d = ac.checkAccess("writer", "e1", "write", "helm");
+			assert.equal(d.allowed, true);
+		});
+
+		it("denies out-of-scope writes", () => {
+			const d = ac.checkAccess("writer", "e1", "write", "other-project");
+			assert.equal(d.allowed, false);
+		});
+
+		it("wildcard scope matches everything", () => {
+			assert.equal(ac.checkAccess("reader", "e1", "read", "any-scope").allowed, true);
+		});
+	});
+
+	describe("entry overrides", () => {
+		it("override takes precedence over grants", () => {
+			ac.setEntryOverride({
+				entryId: "special-entry",
+				agentId: "reader",
+				level: "admin",
+				setBy: "Admiral",
+				setAt: new Date().toISOString(),
+			});
+			const d = ac.checkAccess("reader", "special-entry", "delete");
+			assert.equal(d.allowed, true);
+		});
+
+		it("replaces existing override for same agent", () => {
+			ac.setEntryOverride({
+				entryId: "e1",
+				agentId: "reader",
+				level: "admin",
+				setBy: "a",
+				setAt: new Date().toISOString(),
+			});
+			ac.setEntryOverride({
+				entryId: "e1",
+				agentId: "reader",
+				level: "read-only",
+				setBy: "a",
+				setAt: new Date().toISOString(),
+			});
+			const d = ac.checkAccess("reader", "e1", "write");
+			assert.equal(d.allowed, false);
+		});
+	});
+
+	describe("filterReadable", () => {
+		it("filters entries by read access", () => {
+			ac.setEntryOverride({
+				entryId: "secret",
+				agentId: "reader",
+				level: "read-only",
+				setBy: "a",
+				setAt: "",
+			});
+			// reader has wildcard read-only, can read all
+			const readable = ac.filterReadable(["e1", "e2", "secret"], "reader");
+			assert.equal(readable.length, 3);
+		});
+	});
+
+	describe("filterWritable", () => {
+		it("filters entries by write access", () => {
+			const scopes = new Map([
+				["e1", "helm"],
+				["e2", "helm"],
+				["e3", "other"],
+			]);
+			const writable = ac.filterWritable(["e1", "e2", "e3"], "writer", scopes);
+			assert.equal(writable.length, 2);
+		});
+	});
+
+	describe("decision log", () => {
+		it("logs all access decisions", () => {
+			ac.checkAccess("reader", "e1", "read");
+			ac.checkAccess("reader", "e1", "write");
+			assert.equal(ac.getDecisionLog().length, 2);
+		});
+
+		it("filters by agent", () => {
+			ac.checkAccess("reader", "e1", "read");
+			ac.checkAccess("writer", "e1", "write", "helm");
+			assert.equal(ac.getAgentDecisions("reader").length, 1);
+		});
+	});
+
+	describe("grant management", () => {
+		it("returns agent grants", () => {
+			assert.equal(ac.getAgentGrants("reader").length, 1);
+		});
+
+		it("revokes all grants", () => {
+			const count = ac.revokeAll("reader");
+			assert.equal(count, 1);
+			assert.equal(ac.getAgentGrants("reader").length, 0);
+		});
+	});
+
+	describe("expired grants", () => {
+		it("ignores expired grants", () => {
+			ac.grant({
+				agentId: "temp-writer",
+				level: "contributor",
+				scope: "*",
+				grantedBy: "Admiral",
+				grantedAt: "2024-01-01T00:00:00Z",
+				expiresAt: "2024-01-02T00:00:00Z",
+			});
+			const d = ac.checkAccess("temp-writer", "e1", "write");
+			assert.equal(d.allowed, false);
+		});
+	});
+});

--- a/admiral/brain/access-control.ts
+++ b/admiral/brain/access-control.ts
@@ -1,0 +1,198 @@
+/**
+ * Brain Access Control Enforcement (B-15)
+ *
+ * Per-agent per-entry clearance levels (read-only, contributor, admin),
+ * write scoping by project, and access decisions logged.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Access level for brain operations */
+export type AccessLevel = "read-only" | "contributor" | "admin";
+
+/** Access level numeric ordering */
+const ACCESS_ORDER: Record<AccessLevel, number> = {
+	"read-only": 0,
+	contributor: 1,
+	admin: 2,
+};
+
+/** Per-agent access grant */
+export interface AccessGrant {
+	agentId: string;
+	level: AccessLevel;
+	scope: string;
+	grantedBy: string;
+	grantedAt: string;
+	expiresAt?: string;
+}
+
+/** Per-entry access override */
+export interface EntryAccessOverride {
+	entryId: string;
+	agentId: string;
+	level: AccessLevel;
+	setBy: string;
+	setAt: string;
+}
+
+/** Access decision record */
+export interface AccessDecision {
+	agentId: string;
+	entryId: string;
+	operation: "read" | "write" | "delete" | "admin";
+	allowed: boolean;
+	reason: string;
+	timestamp: string;
+	effectiveLevel: AccessLevel;
+	requiredLevel: AccessLevel;
+}
+
+/** Operation to minimum access level mapping */
+const OPERATION_REQUIREMENTS: Record<string, AccessLevel> = {
+	read: "read-only",
+	write: "contributor",
+	delete: "admin",
+	admin: "admin",
+};
+
+// ---------------------------------------------------------------------------
+// AccessController
+// ---------------------------------------------------------------------------
+
+export class AccessController {
+	private grants: Map<string, AccessGrant[]> = new Map();
+	private entryOverrides: Map<string, EntryAccessOverride[]> = new Map();
+	private decisions: AccessDecision[] = [];
+	private defaultLevel: AccessLevel;
+
+	constructor(defaultLevel: AccessLevel = "read-only") {
+		this.defaultLevel = defaultLevel;
+	}
+
+	/** Grant access level to an agent for a scope */
+	grant(grant: AccessGrant): void {
+		const agentGrants = this.grants.get(grant.agentId) ?? [];
+		agentGrants.push(grant);
+		this.grants.set(grant.agentId, agentGrants);
+	}
+
+	/** Set per-entry access override */
+	setEntryOverride(override: EntryAccessOverride): void {
+		const overrides = this.entryOverrides.get(override.entryId) ?? [];
+		// Replace existing override for same agent
+		const idx = overrides.findIndex((o) => o.agentId === override.agentId);
+		if (idx >= 0) {
+			overrides[idx] = override;
+		} else {
+			overrides.push(override);
+		}
+		this.entryOverrides.set(override.entryId, overrides);
+	}
+
+	/** Get effective access level for an agent on a specific entry */
+	getEffectiveLevel(
+		agentId: string,
+		entryId: string,
+		entryScope?: string,
+	): AccessLevel {
+		// Check per-entry override first (highest priority)
+		const overrides = this.entryOverrides.get(entryId) ?? [];
+		const entryOverride = overrides.find((o) => o.agentId === agentId);
+		if (entryOverride) return entryOverride.level;
+
+		// Check agent grants matching scope
+		const agentGrants = this.grants.get(agentId) ?? [];
+		const now = new Date().toISOString();
+
+		let highestLevel = this.defaultLevel;
+		for (const grant of agentGrants) {
+			// Skip expired grants
+			if (grant.expiresAt && grant.expiresAt < now) continue;
+
+			// Check scope match (wildcard "*" matches everything)
+			if (grant.scope === "*" || grant.scope === entryScope) {
+				if (ACCESS_ORDER[grant.level] > ACCESS_ORDER[highestLevel]) {
+					highestLevel = grant.level;
+				}
+			}
+		}
+
+		return highestLevel;
+	}
+
+	/** Check if an agent can perform an operation on an entry */
+	checkAccess(
+		agentId: string,
+		entryId: string,
+		operation: "read" | "write" | "delete" | "admin",
+		entryScope?: string,
+	): AccessDecision {
+		const effectiveLevel = this.getEffectiveLevel(agentId, entryId, entryScope);
+		const requiredLevel = OPERATION_REQUIREMENTS[operation];
+		const allowed = ACCESS_ORDER[effectiveLevel] >= ACCESS_ORDER[requiredLevel];
+
+		const decision: AccessDecision = {
+			agentId,
+			entryId,
+			operation,
+			allowed,
+			reason: allowed
+				? `${effectiveLevel} access sufficient for ${operation}`
+				: `${effectiveLevel} access insufficient for ${operation} (requires ${requiredLevel})`,
+			timestamp: new Date().toISOString(),
+			effectiveLevel,
+			requiredLevel,
+		};
+
+		this.decisions.push(decision);
+		return decision;
+	}
+
+	/** Filter entries that an agent can read */
+	filterReadable(entryIds: string[], agentId: string, entryScopes?: Map<string, string>): string[] {
+		return entryIds.filter((id) => {
+			const scope = entryScopes?.get(id);
+			return this.checkAccess(agentId, id, "read", scope).allowed;
+		});
+	}
+
+	/** Filter entries that an agent can write */
+	filterWritable(entryIds: string[], agentId: string, entryScopes?: Map<string, string>): string[] {
+		return entryIds.filter((id) => {
+			const scope = entryScopes?.get(id);
+			return this.checkAccess(agentId, id, "write", scope).allowed;
+		});
+	}
+
+	/** Get access decision log */
+	getDecisionLog(): AccessDecision[] {
+		return [...this.decisions];
+	}
+
+	/** Get decisions for a specific agent */
+	getAgentDecisions(agentId: string): AccessDecision[] {
+		return this.decisions.filter((d) => d.agentId === agentId);
+	}
+
+	/** Get grants for an agent */
+	getAgentGrants(agentId: string): AccessGrant[] {
+		return [...(this.grants.get(agentId) ?? [])];
+	}
+
+	/** Revoke all grants for an agent */
+	revokeAll(agentId: string): number {
+		const count = (this.grants.get(agentId) ?? []).length;
+		this.grants.delete(agentId);
+		return count;
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.grants.clear();
+		this.entryOverrides.clear();
+		this.decisions = [];
+	}
+}

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -52,7 +52,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 - [~] **B-12** MCP server scaffold — 8 tool endpoints (brain_record, brain_query, brain_retrieve, brain_strengthen, brain_supersede, brain_status, brain_audit, brain_purge) *(partial — see audit)*
 - [ ] **B-13** Postgres + pgvector schema deployment — migrations, rollback, connection pooling
 - [x] **B-14** Identity token lifecycle — *Completed in Phase 10.* — `admiral/brain/identity-tokens.ts` with create (configurable TTL), rotate (overlapping validity window), revoke (immediate), validate, bulk agent revocation, auto-expiry pruning, stats. 20-test suite.
-- [ ] **B-15** Access control enforcement — per-agent per-entry clearance levels (read-only, contributor, admin), write scoping by project, access decisions logged
+- [x] **B-15** Access control enforcement — *Completed in Phase 10.* — `admiral/brain/access-control.ts` with 3 access levels (read-only/contributor/admin), scope-based grants, per-entry overrides, expired grant handling, readable/writable filtering, full decision audit log. 18-test suite.
 
 ## B3 Advanced
 


### PR DESCRIPTION
## Summary
- Add `admiral/brain/access-control.ts` — per-agent per-entry access control
- 3 access levels: read-only, contributor, admin
- Scope-based grants, per-entry overrides, expired grant handling
- Readable/writable filtering, full decision audit log

## Test plan
- [x] 18 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)