### PR TITLE
feat(b-10): embedding generation pipeline

### DIFF
--- a/admiral/brain/embedding-pipeline.test.ts
+++ b/admiral/brain/embedding-pipeline.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+import {
+	EmbeddingPipeline,
+	HashEmbeddingBackend,
+} from "./embedding-pipeline";
+import type { EmbeddingBackend, EmbeddingVector } from "./embedding-pipeline";
+
+describe("EmbeddingPipeline", () => {
+	let pipeline: EmbeddingPipeline;
+
+	beforeEach(() => {
+		pipeline = new EmbeddingPipeline(new HashEmbeddingBackend(64, "1.0.0"));
+	});
+
+	describe("generateEmbedding", () => {
+		it("generates embedding for a single entry", async () => {
+			const result = await pipeline.generateEmbedding("e1", "Hello world");
+			assert.equal(result.success, true);
+			assert.equal(result.dimensions, 64);
+			assert.equal(result.entryId, "e1");
+		});
+
+		it("stores the embedding", async () => {
+			await pipeline.generateEmbedding("e1", "Hello world");
+			const stored = pipeline.getEmbedding("e1");
+			assert.ok(stored);
+			assert.equal(stored.entryId, "e1");
+			assert.equal(stored.vector.length, 64);
+			assert.equal(stored.modelName, "hash-embedding");
+			assert.equal(stored.modelVersion, "1.0.0");
+		});
+
+		it("handles backend errors gracefully", async () => {
+			const failBackend: EmbeddingBackend = {
+				name: "fail",
+				modelVersion: "1.0",
+				dimensions: 64,
+				embed: async () => { throw new Error("API error"); },
+				embedBatch: async () => { throw new Error("API error"); },
+			};
+			const failPipeline = new EmbeddingPipeline(failBackend);
+			const result = await failPipeline.generateEmbedding("e1", "test");
+			assert.equal(result.success, false);
+			assert.ok(result.error?.includes("API error"));
+		});
+	});
+
+	describe("generateBatch", () => {
+		it("generates embeddings for multiple entries", async () => {
+			const results = await pipeline.generateBatch([
+				{ id: "e1", text: "First entry" },
+				{ id: "e2", text: "Second entry" },
+				{ id: "e3", text: "Third entry" },
+			]);
+			assert.equal(results.length, 3);
+			assert.ok(results.every((r) => r.success));
+		});
+	});
+
+	describe("needsReembedding", () => {
+		it("returns true for unknown entries", () => {
+			assert.equal(pipeline.needsReembedding("unknown", "text"), true);
+		});
+
+		it("returns false for up-to-date entries", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			assert.equal(pipeline.needsReembedding("e1", "Hello"), false);
+		});
+
+		it("returns true when text changes", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			assert.equal(pipeline.needsReembedding("e1", "World"), true);
+		});
+
+		it("returns true after model switch", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			pipeline.switchBackend(new HashEmbeddingBackend(64, "2.0.0"));
+			assert.equal(pipeline.needsReembedding("e1", "Hello"), true);
+		});
+	});
+
+	describe("switchBackend", () => {
+		it("updates the active backend", () => {
+			pipeline.switchBackend(new HashEmbeddingBackend(128, "2.0.0"));
+			const info = pipeline.getBackendInfo();
+			assert.equal(info.version, "2.0.0");
+			assert.equal(info.dimensions, 128);
+		});
+
+		it("records model history", () => {
+			pipeline.switchBackend(new HashEmbeddingBackend(128, "2.0.0"));
+			const history = pipeline.getModelHistory();
+			assert.equal(history.length, 2);
+			assert.equal(history[0].version, "1.0.0");
+			assert.equal(history[1].version, "2.0.0");
+		});
+	});
+
+	describe("reembedAll", () => {
+		it("re-embeds stale entries after model switch", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			await pipeline.generateEmbedding("e2", "World");
+
+			pipeline.switchBackend(new HashEmbeddingBackend(64, "2.0.0"));
+
+			const report = await pipeline.reembedAll([
+				{ id: "e1", text: "Hello" },
+				{ id: "e2", text: "World" },
+			]);
+			assert.equal(report.reembedded, 2);
+			assert.equal(report.skipped, 0);
+			assert.ok(report.newModel.includes("2.0.0"));
+		});
+
+		it("skips up-to-date entries", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			const report = await pipeline.reembedAll([
+				{ id: "e1", text: "Hello" },
+			]);
+			assert.equal(report.skipped, 1);
+			assert.equal(report.reembedded, 0);
+		});
+	});
+
+	describe("getStats", () => {
+		it("returns correct statistics", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			await pipeline.generateEmbedding("e2", "World");
+
+			const stats = pipeline.getStats(["e1", "e2", "e3"]);
+			assert.equal(stats.totalEmbeddings, 2);
+			assert.equal(stats.pendingEntries, 1);
+			assert.equal(stats.staleEmbeddings, 0);
+		});
+
+		it("detects stale embeddings after model switch", async () => {
+			await pipeline.generateEmbedding("e1", "Hello");
+			pipeline.switchBackend(new HashEmbeddingBackend(64, "2.0.0"));
+
+			const stats = pipeline.getStats(["e1"]);
+			assert.equal(stats.staleEmbeddings, 1);
+		});
+	});
+
+	describe("HashEmbeddingBackend", () => {
+		it("produces normalized vectors", async () => {
+			const backend = new HashEmbeddingBackend(32);
+			const vector = await backend.embed("test input");
+			const magnitude = Math.sqrt(vector.reduce((s, v) => s + v * v, 0));
+			assert.ok(Math.abs(magnitude - 1.0) < 0.01, `Magnitude ${magnitude} should be ~1.0`);
+		});
+
+		it("produces different vectors for different inputs", async () => {
+			const backend = new HashEmbeddingBackend(32);
+			const v1 = await backend.embed("apple");
+			const v2 = await backend.embed("banana");
+			const same = v1.every((val, i) => val === v2[i]);
+			assert.equal(same, false);
+		});
+
+		it("batch produces same results as individual", async () => {
+			const backend = new HashEmbeddingBackend(32);
+			const [v1, v2] = await backend.embedBatch(["apple", "banana"]);
+			const v1Solo = await backend.embed("apple");
+			assert.deepEqual(v1, v1Solo);
+		});
+	});
+});

--- a/admiral/brain/embedding-pipeline.ts
+++ b/admiral/brain/embedding-pipeline.ts
@@ -1,0 +1,278 @@
+/**
+ * Embedding Generation Pipeline (B-10)
+ *
+ * Pluggable backends (API or pre-computed), model version tracking,
+ * and re-embedding on model change. Generates vector embeddings for
+ * Brain entries to enable semantic search (B-11).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Embedding vector */
+export type EmbeddingVector = number[];
+
+/** Embedding backend interface — implement for each provider */
+export interface EmbeddingBackend {
+	readonly name: string;
+	readonly modelVersion: string;
+	readonly dimensions: number;
+	embed(text: string): Promise<EmbeddingVector>;
+	embedBatch(texts: string[]): Promise<EmbeddingVector[]>;
+}
+
+/** Stored embedding with metadata */
+export interface StoredEmbedding {
+	entryId: string;
+	vector: EmbeddingVector;
+	modelName: string;
+	modelVersion: string;
+	generatedAt: number;
+	textHash: string;
+}
+
+/** Embedding generation result */
+export interface EmbeddingResult {
+	entryId: string;
+	success: boolean;
+	dimensions?: number;
+	error?: string;
+}
+
+/** Pipeline statistics */
+export interface PipelineStats {
+	totalEmbeddings: number;
+	staleEmbeddings: number;
+	pendingEntries: number;
+	currentModel: string;
+	currentVersion: string;
+}
+
+/** Re-embedding report */
+export interface ReembeddingReport {
+	reembedded: number;
+	skipped: number;
+	failed: number;
+	previousModel: string;
+	newModel: string;
+	startedAt: number;
+	completedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in backends
+// ---------------------------------------------------------------------------
+
+/** Simple hash-based embedding for testing (not for production) */
+export class HashEmbeddingBackend implements EmbeddingBackend {
+	readonly name = "hash-embedding";
+	readonly modelVersion: string;
+	readonly dimensions: number;
+
+	constructor(dimensions = 128, version = "1.0.0") {
+		this.dimensions = dimensions;
+		this.modelVersion = version;
+	}
+
+	async embed(text: string): Promise<EmbeddingVector> {
+		return this.hashToVector(text);
+	}
+
+	async embedBatch(texts: string[]): Promise<EmbeddingVector[]> {
+		return texts.map((t) => this.hashToVector(t));
+	}
+
+	private hashToVector(text: string): EmbeddingVector {
+		const vector: number[] = new Array(this.dimensions).fill(0);
+		for (let i = 0; i < text.length; i++) {
+			const idx = i % this.dimensions;
+			vector[idx] += text.charCodeAt(i) / 1000;
+		}
+		// Normalize
+		const magnitude = Math.sqrt(vector.reduce((s, v) => s + v * v, 0)) || 1;
+		return vector.map((v) => v / magnitude);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EmbeddingPipeline
+// ---------------------------------------------------------------------------
+
+/** Simple hash of text for change detection */
+function textHash(text: string): string {
+	let hash = 0;
+	for (let i = 0; i < text.length; i++) {
+		const char = text.charCodeAt(i);
+		hash = ((hash << 5) - hash + char) | 0;
+	}
+	return hash.toString(36);
+}
+
+export class EmbeddingPipeline {
+	private backend: EmbeddingBackend;
+	private embeddings: Map<string, StoredEmbedding> = new Map();
+	private modelHistory: Array<{ name: string; version: string; switchedAt: number }> = [];
+
+	constructor(backend: EmbeddingBackend) {
+		this.backend = backend;
+		this.modelHistory.push({
+			name: backend.name,
+			version: backend.modelVersion,
+			switchedAt: Date.now(),
+		});
+	}
+
+	/** Generate embedding for a single entry */
+	async generateEmbedding(entryId: string, text: string): Promise<EmbeddingResult> {
+		try {
+			const vector = await this.backend.embed(text);
+			const stored: StoredEmbedding = {
+				entryId,
+				vector,
+				modelName: this.backend.name,
+				modelVersion: this.backend.modelVersion,
+				generatedAt: Date.now(),
+				textHash: textHash(text),
+			};
+			this.embeddings.set(entryId, stored);
+			return { entryId, success: true, dimensions: vector.length };
+		} catch (err) {
+			return {
+				entryId,
+				success: false,
+				error: err instanceof Error ? err.message : String(err),
+			};
+		}
+	}
+
+	/** Generate embeddings for multiple entries */
+	async generateBatch(
+		entries: Array<{ id: string; text: string }>,
+	): Promise<EmbeddingResult[]> {
+		const results: EmbeddingResult[] = [];
+		try {
+			const vectors = await this.backend.embedBatch(entries.map((e) => e.text));
+			for (let i = 0; i < entries.length; i++) {
+				const stored: StoredEmbedding = {
+					entryId: entries[i].id,
+					vector: vectors[i],
+					modelName: this.backend.name,
+					modelVersion: this.backend.modelVersion,
+					generatedAt: Date.now(),
+					textHash: textHash(entries[i].text),
+				};
+				this.embeddings.set(entries[i].id, stored);
+				results.push({ entryId: entries[i].id, success: true, dimensions: vectors[i].length });
+			}
+		} catch (err) {
+			for (const entry of entries) {
+				results.push({
+					entryId: entry.id,
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+		return results;
+	}
+
+	/** Get stored embedding for an entry */
+	getEmbedding(entryId: string): StoredEmbedding | undefined {
+		return this.embeddings.get(entryId);
+	}
+
+	/** Check if an entry needs re-embedding (model changed or text changed) */
+	needsReembedding(entryId: string, currentText: string): boolean {
+		const existing = this.embeddings.get(entryId);
+		if (!existing) return true;
+		if (existing.modelVersion !== this.backend.modelVersion) return true;
+		if (existing.modelName !== this.backend.name) return true;
+		if (existing.textHash !== textHash(currentText)) return true;
+		return false;
+	}
+
+	/** Switch to a new embedding backend */
+	switchBackend(newBackend: EmbeddingBackend): void {
+		this.backend = newBackend;
+		this.modelHistory.push({
+			name: newBackend.name,
+			version: newBackend.modelVersion,
+			switchedAt: Date.now(),
+		});
+	}
+
+	/** Re-embed all entries that are stale (wrong model/version) */
+	async reembedAll(
+		entries: Array<{ id: string; text: string }>,
+	): Promise<ReembeddingReport> {
+		const report: ReembeddingReport = {
+			reembedded: 0,
+			skipped: 0,
+			failed: 0,
+			previousModel: this.modelHistory.length > 1
+				? `${this.modelHistory[this.modelHistory.length - 2].name}@${this.modelHistory[this.modelHistory.length - 2].version}`
+				: "none",
+			newModel: `${this.backend.name}@${this.backend.modelVersion}`,
+			startedAt: Date.now(),
+			completedAt: 0,
+		};
+
+		for (const entry of entries) {
+			if (!this.needsReembedding(entry.id, entry.text)) {
+				report.skipped++;
+				continue;
+			}
+			const result = await this.generateEmbedding(entry.id, entry.text);
+			if (result.success) {
+				report.reembedded++;
+			} else {
+				report.failed++;
+			}
+		}
+
+		report.completedAt = Date.now();
+		return report;
+	}
+
+	/** Get pipeline statistics */
+	getStats(knownEntryIds?: string[]): PipelineStats {
+		const stale = knownEntryIds
+			? knownEntryIds.filter((id) => {
+					const e = this.embeddings.get(id);
+					return e && (e.modelVersion !== this.backend.modelVersion || e.modelName !== this.backend.name);
+				}).length
+			: 0;
+
+		const pending = knownEntryIds
+			? knownEntryIds.filter((id) => !this.embeddings.has(id)).length
+			: 0;
+
+		return {
+			totalEmbeddings: this.embeddings.size,
+			staleEmbeddings: stale,
+			pendingEntries: pending,
+			currentModel: this.backend.name,
+			currentVersion: this.backend.modelVersion,
+		};
+	}
+
+	/** Get model history */
+	getModelHistory(): Array<{ name: string; version: string; switchedAt: number }> {
+		return [...this.modelHistory];
+	}
+
+	/** Get current backend info */
+	getBackendInfo(): { name: string; version: string; dimensions: number } {
+		return {
+			name: this.backend.name,
+			version: this.backend.modelVersion,
+			dimensions: this.backend.dimensions,
+		};
+	}
+
+	/** Reset (for testing) */
+	reset(): void {
+		this.embeddings.clear();
+	}
+}

--- a/plan/todo/08-brain-and-knowledge.md
+++ b/plan/todo/08-brain-and-knowledge.md
@@ -44,7 +44,7 @@ Brain is Admiral's primary competitive moat. Ship B2 within **120 days** before 
 
 ## B2 Semantic Search
 
-- [ ] **B-10** Embedding generation pipeline — pluggable backends (API or pre-computed), model version tracking, re-embedding on model change
+- [x] **B-10** Embedding generation pipeline — *Completed in Phase 10.* — `admiral/brain/embedding-pipeline.ts` with pluggable `EmbeddingBackend` interface, hash-based test backend, model version tracking, text change detection, batch generation, re-embedding on model switch with skip/reembed/fail reporting, pipeline stats. 17-test suite.
 - [ ] **B-11** Similarity search — cosine distance, `brain_query --semantic "topic"`, blend keyword and semantic signals
 
 ## B3 Production


### PR DESCRIPTION
## Summary
- Add `admiral/brain/embedding-pipeline.ts` — pluggable embedding generation
- `EmbeddingBackend` interface for API/pre-computed providers
- Hash-based test backend, model version tracking, batch generation
- Re-embedding on model switch with reporting, pipeline stats

## Test plan
- [x] 17 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)